### PR TITLE
Add the artist profile link to the player controls at the bottom.

### DIFF
--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -370,10 +370,14 @@ class Player extends Nanocomponent {
       hover: false, // disabled activation on mousehover
       items: [
         { iconName: 'star', text: this._fav === 0 ? 'favorite' : 'unfavorite', actionName: 'favorite:toggle' },
-        { iconName: 'share', text: 'share', actionName: 'sharingDialog:open' }
+        { iconName: 'share', text: 'share', actionName: 'sharingDialog:open' },
+        { iconName: 'info', text: 'artist profile', actionName: 'artist:profile' }
       ],
       updateLastAction: (eventName) => {
-        this.machine.emit(eventName)
+        if (eventName === 'artist:profile') {
+          return this.emit(this.state.events.PUSHSTATE, `/artists/${this._trackGroup[0].id}`)
+        }
+        return this.machine.emit(eventName)
       },
       id: `super-button-${this._track.id}`,
       orientation, // popup menu orientation


### PR DESCRIPTION
Before the artist profile link was only being displayed on the player controls for individual tracks. This adds it to the controls at the bottom too.

Fixes https://github.com/resonatecoop/stream2own/issues/11