### PR TITLE
Fix misspelling of breadcrumbs

### DIFF
--- a/beta/elements/breadcrumb.js
+++ b/beta/elements/breadcrumb.js
@@ -3,7 +3,7 @@ const html = require('choo/html')
 module.exports = (props) => {
   const { href, text } = props
   return html`
-    <div class="breadcrump mv3">
+    <div class="breadcrumb mv3">
       <a class="link b f5 dim" href=${href}>${text}</a>
     </div>
   `

--- a/beta/views/artists/albums.js
+++ b/beta/views/artists/albums.js
@@ -1,6 +1,6 @@
 const html = require('choo/html')
 const Albums = require('../../components/albums')
-const breadcrump = require('../../elements/breadcrump')
+const breadcrumb = require('../../elements/breadcrumb')
 
 const viewLayout = require('../../elements/view-layout')
 
@@ -22,7 +22,7 @@ function ArtistAlbumsView () {
     return viewLayout((state, emit) => html`
       <section id="artist-profile" class="flex flex-column flex-auto w-100">
         <section id="content" class="flex flex-column flex-auto w-100 pb6 ph3">
-          ${breadcrump({ href: `/artists/${id}`, text: 'Back to artist profile' })}
+          ${breadcrumb({ href: `/artists/${id}`, text: 'Back to artist profile' })}
           <section id="artist-albums" class="flex-auto">
             <h2 class="lh-title">Albums</h2>
             ${albums}

--- a/beta/views/artists/tracks.js
+++ b/beta/views/artists/tracks.js
@@ -1,7 +1,7 @@
 const html = require('choo/html')
 const Playlist = require('@resonate/playlist-component')
 const viewLayout = require('../../elements/view-layout')
-const breadcrump = require('../../elements/breadcrump')
+const breadcrumb = require('../../elements/breadcrumb')
 
 module.exports = ArtistTracksView
 
@@ -24,7 +24,7 @@ function ArtistTracksView () {
     return viewLayout((state, emit) => html`
       <section id="artist-profile" class="flex flex-column flex-auto w-100">
         <section id="content" class="flex flex-column flex-auto w-100 pb6 ph3">
-          ${breadcrump({ href: `/artists/${id}`, text: 'Back to artist profile' })}
+          ${breadcrumb({ href: `/artists/${id}`, text: 'Back to artist profile' })}
           <section id="artist-playlist" class="flex-auto">
             <h2 class="lh-title">All tracks</h2>
             ${playlist}

--- a/beta/views/labels/albums.js
+++ b/beta/views/labels/albums.js
@@ -1,6 +1,6 @@
 const html = require('choo/html')
 const Albums = require('../../components/albums')
-const breadcrump = require('../../elements/breadcrump')
+const breadcrumb = require('../../elements/breadcrumb')
 const viewLayout = require('../../elements/view-layout')
 
 module.exports = LabelAlbumsView
@@ -20,7 +20,7 @@ function LabelAlbumsView () {
     return viewLayout((state, emit) => html`
       <section id="artist-profile" class="flex flex-column flex-auto w-100">
         <section id="content" class="flex flex-column flex-auto w-100 pb6 ph3">
-          ${breadcrump({ href: `/labels/${id}`, text: 'Back to label profile' })}
+          ${breadcrumb({ href: `/labels/${id}`, text: 'Back to label profile' })}
           <section id="artist-albums" class="flex-auto">
             <h2 class="lh-title">Albums</h2>
             ${albums}

--- a/beta/views/labels/artists.js
+++ b/beta/views/labels/artists.js
@@ -1,6 +1,6 @@
 const html = require('choo/html')
 const Artists = require('../../components/artists')
-const breadcrump = require('../../elements/breadcrump')
+const breadcrumb = require('../../elements/breadcrumb')
 const viewLayout = require('../../elements/view-layout')
 
 module.exports = LabelArtistsView
@@ -20,7 +20,7 @@ function LabelArtistsView () {
     return viewLayout((state, emit) => html`
       <section id="artist-profile" class="flex flex-column flex-auto w-100">
         <section id="content" class="flex flex-column flex-auto w-100 pb6 ph3">
-          ${breadcrump({ href: `/labels/${id}`, text: 'Back to label profile' })}
+          ${breadcrumb({ href: `/labels/${id}`, text: 'Back to label profile' })}
           <section id="label-artists" class="flex-auto">
             <h2 class="lh-title ml3">Artists</h2>
             ${artists}


### PR DESCRIPTION
Probably best to use standard spelling here.

In `/beta/elements/breadcrump.js` a div was given the `.breadcrump` class, but there's no CSS rules for it in this repo. Should I change those elsewhere, or do they not exist?