### PR TITLE
added updated links to github projects and forum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing!
 There are many ways to contribute:
 - Refactoring code
 - Fixing bugs, after reporting them
-- Building new features, based on the roadmap in [README](README.md#roadmap) and related Github issues.
+- Building new features, based on the roadmap on [Github Projects](https://github.com/resonatecoop/stream/projects/) and the [backlog in our community forum](https://community.resonate.is/c/platform/52)
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ## API
 
-If you want to build on the API for personal use, check out the [Migrate to new APIs project](https://github.com/resonatecoop/stream/projects/5#card-59829409) and consider checking the [backlog in our community forum](https://community.resonate.is/c/platform/52). 
+If you want to build on the API for personal use, take a look through the work done in the [Migrate to new APIs project](https://github.com/resonatecoop/stream/projects/5#card-59829409) and consider checking the [backlog in our community forum](https://community.resonate.is/c/platform/52). 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@
 
 ## API
 
-If you want to build on the API for personal use, start with [the API documentation](https://github.com/resonatecoop/stream/blob/develop/docs/api.md).
-Before you start, check out the [Migrate to new APIs project](https://github.com/resonatecoop/stream/projects/5#card-59829409) and consider checking the [backlog in our community forum](https://community.resonate.is/c/platform/52). 
+If you want to build on the API for personal use, check out the [Migrate to new APIs project](https://github.com/resonatecoop/stream/projects/5#card-59829409) and consider checking the [backlog in our community forum](https://community.resonate.is/c/platform/52). 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 </div>
 
 ## Table of Contents
+- [API](#api)
 - [Installation](#installation)
 - [Development](#development)
 - [Environment](#environment)
@@ -48,6 +49,11 @@
 - [Code style](#code-style)
 - [Contributors](#contributors)
 - [See Also](#see-also)
+
+## API
+
+If you want to build on the API for personal use, start with [the API documentation](https://github.com/resonatecoop/stream/blob/develop/docs/api.md).
+Before you start, check out the [Migrate to new APIs project](https://github.com/resonatecoop/stream/projects/5#card-59829409) and consider checking the [backlog in our community forum](https://community.resonate.is/c/platform/52). 
 
 ## Installation
 


### PR DESCRIPTION
[Per discussion in the forum](https://community.resonate.is/t/developer-forums/886/16), it's hard for new potential contributors to know what the current backlog is, especially if they found resonate through a developer lens (looking for open source project to contribute to) or they went to the website and then clicked on the github link (it's open to the public) instead of the forum (not open to the public). 

This is an attempt to help people who find Resonate through GitHub orient themselves independently. 