### PR TITLE
added UI for global recently played tracks

### DIFF
--- a/beta/views/discover/index.js
+++ b/beta/views/discover/index.js
@@ -34,8 +34,11 @@ function renderDiscover (state, emit) {
         <li class="mr3">
           <a href="#releases" onclick=${navigateToAnchor} class="link ttu lh-copy">New releases</a>
         </li>
-        <li>
+        <li class="mr3">
           <a href="/releases?order=random" title="Random releases" class="link dark-gray dark-gray--light gray--dark ttu lh-copy">Random</a>
+        </li>
+        <li class="mr3">
+          <a href="/tracks?order=plays" title="Currently playing" class="link dark-gray dark-gray--light gray--dark ttu lh-copy">Currently playing</a>
         </li>
       </ul>
 

--- a/beta/views/tracks/index.js
+++ b/beta/views/tracks/index.js
@@ -13,6 +13,7 @@ function renderTracks (state, emit) {
       label: 'Order',
       values: [
         { value: '', label: 'Change order', disabled: true },
+        { value: 'plays', label: 'Currently playing' },
         { value: 'random', label: 'Random' },
         { value: 'newest', label: 'Recently added' },
         { value: 'oldest', label: 'Added first' }


### PR DESCRIPTION
Track List:
<img width="1072" alt="Screen Shot 2021-10-20 at 6 17 09 PM" src="https://user-images.githubusercontent.com/2731744/138180225-4839094a-1d3d-4db3-b615-cfcd23add2bc.png"> 

home page suggestion:

<img width="523" alt="Screen Shot 2021-10-20 at 6 17 45 PM" src="https://user-images.githubusercontent.com/2731744/138180295-1483423d-6248-4693-999f-367497a8b32f.png">

@hakanto pls review 

