### PR TITLE
#120 Twitter Card?

### DIFF
--- a/beta/stores/tracks.js
+++ b/beta/stores/tracks.js
@@ -379,8 +379,6 @@ function tracks () {
         'twitter:player': `https://stream.resonate.coop/embed/track/${id}`
       }
 
-      console.log(state.meta)
-
       emitter.emit('meta', state.meta)
     }
   }

--- a/beta/stores/tracks.js
+++ b/beta/stores/tracks.js
@@ -349,7 +349,6 @@ function tracks () {
     function setMeta () {
       const track = state.track.data.track || {}
       const { id, cover, title: trackTitle } = track
-
       const title = {
         'track/:id': trackTitle,
         tracks: 'New tracks'
@@ -371,11 +370,16 @@ function tracks () {
         'og:type': 'website',
         'og:url': `${process.env.API_DOMAIN}/tracks/${id}`,
         'og:description': `Listen to ${trackTitle} on Resonate`,
-        'twitter:card': 'summary_large_image',
+        'twitter:card': 'player',
         'twitter:title': fullTitle,
-        'twitter:image': image,
-        'twitter:site': '@resonatecoop'
+        'twitter:image': cover,
+        'twitter:site': '@resonatecoop',
+        'twitter:player:width': '400',
+        'twitter:player:height': '600',
+        'twitter:player': `https://stream.resonate.coop/embed/track/${id}`
       }
+
+      console.log(state.meta)
 
       emitter.emit('meta', state.meta)
     }


### PR DESCRIPTION
testing out the twitter card validator on a track (https://stream.resonate.coop/track/22931)
https://cards-dev.twitter.com/validator?ref=frontendchecklist

<img width="672" alt="Screen Shot 2021-11-01 at 9 24 57 PM" src="https://user-images.githubusercontent.com/2731744/139771801-2ac5f5f7-60d0-46a8-86fc-9c5ac3c729d2.png">

looks like something wrong with the image? Webp is OK for twitter so updated `'twitter:image': cover,`

> URL of image to use in the card. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.
