### PR TITLE
Removed padding and min vh on login page

### DIFF
--- a/beta/views/login/index.js
+++ b/beta/views/login/index.js
@@ -11,7 +11,7 @@ module.exports = () => viewLayout(renderLogin)
 function renderLogin (state, emit) {
   return html`
     <div class="flex flex-column flex-row-l flex-auto w-100">
-      <div class="flex flex-column flex-auto w-100 items-center justify-center min-vh-100 pt6 pb6">
+      <div class="flex flex-column flex-auto w-100 items-center justify-center pb6">
         <div class="w-100 w-auto-l ph4 pt4 pb3">
           <div class="flex flex-column flex-auto">
             <h2 class="f3 fw1 mt2 near-black near-black--light light-gray--dark lh-title">Log In</h2>


### PR DESCRIPTION
Removing the minimum vh changes mobile view to have login at the top but on web it continues to be centered as it is in a flex box.

Also removed padding that seemed to be doing nothing.

This closes #117 