### PR TITLE
Make player theme selection more intuitive & straightforward

### DIFF
--- a/beta/components/theme-switcher/index.js
+++ b/beta/components/theme-switcher/index.js
@@ -43,7 +43,7 @@ class ThemeSwitcher extends Component {
           <legend class="lh-copy f5 clip">Theme</legend>
           <div class="flex w-100">
             <div class="flex items-center flex-auto">
-              <input tabindex="-1" type="radio" disabled=${!!this.local.auto} name="theme" checked=${this.local.machine.state.theme === 'dark'} id="chooseDark" onchange=${this._handleChange} value="dark">
+              <input tabindex="-1" type="radio" name="theme" checked=${this.local.machine.state.theme === 'dark'} id="chooseDark" onchange=${this._handleChange} value="dark">
               <label tabindex=${this.local.auto ? -1 : 0} onkeypress=${this._handleKeyPress} class="flex flex-auto items-center justify-center w-100" for="chooseDark">
                 <div class="pv3 flex justify-center w-100 flex-auto">
                   ${icon('circle', { class: `icon icon--sm ${iconFillInvert}` })}
@@ -54,7 +54,7 @@ class ThemeSwitcher extends Component {
               </label>
             </div>
             <div class="flex items-center flex-auto">
-              <input tabindex="-1" type="radio" disabled=${!!this.local.auto} name="theme" checked=${this.local.machine.state.theme === 'light'} id="chooseLight" onchange=${this._handleChange} value="light">
+              <input tabindex="-1" type="radio" name="theme" checked=${this.local.machine.state.theme === 'light'} id="chooseLight" onchange=${this._handleChange} value="light">
               <label tabindex=${this.local.auto ? -1 : 0} onkeypress=${this._handleKeyPress} class="flex flex-auto items-center justify-center w-100" for="chooseLight">
                 <div class="pv3 flex justify-center w-100 flex-auto">
                   ${icon('circle', { class: `icon icon--sm ${iconFillInvert}` })}
@@ -65,10 +65,10 @@ class ThemeSwitcher extends Component {
               </label>
             </div>
             <div class="flex items-center flex-auto">
-              <input tabindex="-1" type="checkbox" name="theme" checked=${!!this.local.auto} id="chooseAuto" onchange=${this._handleAutoChange} value="auto">
+              <input tabindex="-1" type="radio" name="theme" checked=${!!this.local.auto} id="chooseAuto" onchange=${this._handleAutoChange} value="auto">
               <label tabindex="0" onkeypress=${this._handleAutoChangeKeyPress} class="flex flex-auto items-center justify-center w-100" for="chooseAuto">
                 <div class="pv3 flex justify-center w-100 flex-auto">
-                  ${icon('square', { class: `icon icon--sm ${iconFillInvert}` })}
+                  ${icon('circle', { class: `icon icon--sm ${iconFillInvert}` })}
                 </div>
                 <div class="flex flex-auto w-100 pv3">
                   Auto
@@ -84,6 +84,16 @@ class ThemeSwitcher extends Component {
   load (el) {
     this.local.auto = localStorage !== null && !!localStorage.getItem('color-scheme-auto')
     this.rerender()
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    if (
+      this.state.theme === 'light' &&
+      this.local.auto &&
+      prefersDark
+    ) {
+      this.state.theme = 'dark'
+      this.local.machine.emit('theme:toggle')
+    }
   }
 
   _handleAutoChange () {
@@ -104,6 +114,10 @@ class ThemeSwitcher extends Component {
   }
 
   _handleChange (e) {
+    if (e.target.value !== 'auto' && this.local.auto) {
+      this._handleAutoChange(e)
+    }
+
     if (this.local.machine.state.theme !== e.target.value) {
       this.local.machine.emit('theme:toggle')
     }
@@ -112,6 +126,10 @@ class ThemeSwitcher extends Component {
   _handleKeyPress (e) {
     if (e.key === 'Enter') {
       e.preventDefault()
+
+      if (e.target.value !== 'auto' && this.local.auto) {
+        this._handleAutoChange(e)
+      }
 
       if (!e.target.control.checked && this.local.machine.state.theme !== e.target.value) {
         e.target.control.checked = !e.target.control.checked

--- a/beta/components/theme-switcher/index.js
+++ b/beta/components/theme-switcher/index.js
@@ -84,15 +84,16 @@ class ThemeSwitcher extends Component {
   load (el) {
     this.local.auto = localStorage !== null && !!localStorage.getItem('color-scheme-auto')
     this.rerender()
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
     if (
+      window !== undefined &&
+      window.matchMedia('(prefers-color-scheme: dark)') !== undefined &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches !== undefined && 
+      window.matchMedia('(prefers-color-scheme: dark)').matches &&
       this.state.theme === 'light' &&
-      this.local.auto &&
-      prefersDark
-    ) {
-      this.state.theme = 'dark'
-      this.local.machine.emit('theme:toggle')
+      this.local.auto
+      ) {
+        this.state.theme = 'dark'
+        this.local.machine.emit('theme:toggle')
     }
   }
 

--- a/beta/components/theme-switcher/index.js
+++ b/beta/components/theme-switcher/index.js
@@ -84,16 +84,16 @@ class ThemeSwitcher extends Component {
   load (el) {
     this.local.auto = localStorage !== null && !!localStorage.getItem('color-scheme-auto')
     this.rerender()
+
     if (
       window !== undefined &&
       window.matchMedia('(prefers-color-scheme: dark)') !== undefined &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches !== undefined && 
+      window.matchMedia('(prefers-color-scheme: dark)').matches !== undefined &&
       window.matchMedia('(prefers-color-scheme: dark)').matches &&
       this.state.theme === 'light' &&
       this.local.auto
-      ) {
-        this.state.theme = 'dark'
-        this.local.machine.emit('theme:toggle')
+    ) {
+      this.local.machine.emit('theme:toggle')
     }
   }
 


### PR DESCRIPTION
This makes `Auto` theme one of three equally selectable options, along with `Light` and `Dark`, and the default, and changes `Auto` from a `checkbox` to a `radio` style input, such as the `Light` and `Dark` already have.

The `Auto` option also now properly detects user system preferences, and if the user previously had `Auto` selected (detected via `localStorage`).

If the user is using a dark mode on their system, it now honors their preferences on the initial page load. Previously, for users whose computers are in dark mode (at least on my system), on the initial page load, the website would appear light, even though it appears that `Auto` is the default. When I would toggle `Auto` off and on again (and for all subsequent toggles) when it was a checkbox, the website would appear dark, and seemed to have figured out the user's system preference by then. These changes fix that, and now the behavior for `Auto` is consistent between the initial default `Auto` and subsequent theme changes (switching off of `Auto` and then back, etc). 

I wanted to make sure that the initial load of `Auto` defaulting to light mode was a indeed a bug that I fixed and not intentional, so I've included ample screenshots below to keep everyone on the same page as to how exactly this functionality is being adjusted.

This closes https://github.com/resonatecoop/stream/issues/123.

**Screenshot walk-through of all of the different possible scenarios:**
Light system user is logged out, website defaults to `Auto`
<img width="1042" alt="light-system-user-logged-out" src="https://user-images.githubusercontent.com/60944077/147858392-6cc0bd39-d2f7-414c-abe1-e4ac21b79fd4.png">

Light system user logs in, website defaults to `Auto`
<img width="1042" alt="light-system-user-logged-in-auto" src="https://user-images.githubusercontent.com/60944077/147858539-ce659067-4208-43b7-861b-98c011cd5604.png">

Light system user logs in, then switches to `Light` theme
<img width="1043" alt="light-system-user-logged-in-light" src="https://user-images.githubusercontent.com/60944077/147858395-30186dac-2e83-44ee-bbb5-3444e7453928.png">

Light system user logs in, then switches to `Dark` theme
<img width="1042" alt="light-system-user-logged-in-dark" src="https://user-images.githubusercontent.com/60944077/147858552-136aff68-c091-4ee8-be55-e7fca64acf67.png">

Dark system user is logged out, website defaults to `Auto`
<img width="1041" alt="dark-system-user-logged-out" src="https://user-images.githubusercontent.com/60944077/147858400-1918c438-025a-4d8f-8eda-4699f5f785d8.png">

Dark system user logs in, website defaults to `Auto`
<img width="1042" alt="dark-system-user-logged-in-auto" src="https://user-images.githubusercontent.com/60944077/147858403-749aae15-d5d1-4d5f-91cc-8e9746e5f375.png">

Dark system user logs in, then switches to `Light` theme
<img width="1042" alt="dark-system-user-logged-in-light" src="https://user-images.githubusercontent.com/60944077/147859374-72222111-2af9-45a3-b6af-c7648be80c52.png">

Light system user logs in, then switches to `Dark` theme
<img width="1042" alt="dark-system-user-logged-in-dark" src="https://user-images.githubusercontent.com/60944077/147858410-b43746c8-3be9-4201-a7c4-a49ce184365d.png">