### PR TITLE
Pretty social unfurl for artist, label, trackgroup

### DIFF
--- a/beta/stores/artists.js
+++ b/beta/stores/artists.js
@@ -241,7 +241,7 @@ function artists () {
     }
 
     function setMeta () {
-      const { name, images = {}, description } = state.artist.data
+      const { name, images = {}, description = `Listen to ${name} on Resonate` } = state.artist.data
 
       const title = {
         artists: 'Artists',
@@ -264,17 +264,18 @@ function artists () {
 
       state.meta = {
         title: setTitle(title),
+        'og:description': description,
         'og:title': setTitle(title),
         'og:type': 'website',
         'og:url': 'https://beta.stream.resonate.coop' + state.href,
-        'og:description': description || `Listen to ${name} on Resonate`,
         'twitter:card': 'summary_large_image',
-        'twitter:title': setTitle(title),
-        'twitter:site': '@resonatecoop'
+        'twitter:description': description,
+        'twitter:site': '@resonatecoop',
+        'twitter:title': setTitle(title)
       }
 
-      if (image) {
-        state.meta['og:image'] = image
+      if (cover || image) {
+        state.meta['og:image'] = cover || image
         state.meta['twitter:image'] = cover || image
       }
 

--- a/beta/stores/labels.js
+++ b/beta/stores/labels.js
@@ -443,7 +443,7 @@ function labels () {
     }
 
     function setMeta () {
-      const { name, images = {}, description } = state.label.data
+      const { name, images = {}, description = `Listen to ${name} on Resonate` } = state.label.data
 
       const title = {
         labels: 'Labels',
@@ -467,18 +467,19 @@ function labels () {
 
       state.meta = {
         title: setTitle(title),
+        'og:description': description,
         'og:title': setTitle(title),
         'og:type': 'website',
         'og:url': 'https://beta.stream.resonate.coop' + state.href,
-        'og:description': description || `Listen to ${name} on Resonate`,
         'twitter:card': 'summary_large_image',
-        'twitter:title': setTitle(title),
-        'twitter:site': '@resonatecoop'
+        'twitter:description': description,
+        'twitter:site': '@resonatecoop',
+        'twitter:title': setTitle(title)
       }
 
-      if (image) {
-        state.meta['og:image'] = image
-        state.meta['twitter:image'] = cover || image
+      if (image || cover) {
+        state.meta['og:image'] = image || cover
+        state.meta['twitter:image'] = image || cover
       }
 
       emitter.emit('meta', state.meta)

--- a/beta/stores/releases.js
+++ b/beta/stores/releases.js
@@ -340,13 +340,21 @@ function releases () {
 
       state.meta = {
         title: setTitle(title),
+        'og:description': state.release.data.about || 'Browse new releases',
         'og:title': setTitle(title),
         'og:type': 'website',
         'og:url': 'https://beta.stream.resonate.coop' + state.href,
-        'og:description': 'Browse new releases',
         'twitter:card': 'summary_large_image',
-        'twitter:title': setTitle(title),
-        'twitter:site': '@resonatecoop'
+        'twitter:description': state.release.data.about || 'Browse new releases',
+        'twitter:site': '@resonatecoop',
+        'twitter:title': setTitle(title)
+      }
+
+      const image = state.release.data.cover || state.release.data.images.large || state.release.data.images.medium || state.release.data.images.small || false
+
+      if (image) {
+        state.meta['og:image'] = image
+        state.meta['twitter:image'] = image
       }
 
       emitter.emit('meta', state.meta)


### PR DESCRIPTION
Linking to artists, labels, releases on Twitter should now show descriptions and images where possible, using appropriate `meta` tags from [Twitter's summary card with large image](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image) documentation.

I've also alphabetized the properties of the `meta` tag objects, and attempted to make some of the logic slightly more intuitive.

This closes #129.