### PR TITLE
Handle private playlist share

### DIFF
--- a/beta/views/playlist/index.js
+++ b/beta/views/playlist/index.js
@@ -78,7 +78,7 @@ function renderPlaylist (state, emit) {
           <div class="flex items-center absolute z-999 right-0 mr1-l" style="top:100%">
             ${state.cache(MenuButtonOptions, `menu-button-options-playlist-${slug}`).render({
               items: [], // no custom items yet
-              selection: ['share', 'profile'],
+              selection: [props.private ? 'edit' : 'share', 'profile'],
               data: {
                 creator_id: creatorId,
                 cover: cover,

--- a/packages/menu-button-options-component/index.js
+++ b/packages/menu-button-options-component/index.js
@@ -477,6 +477,12 @@ function menuButtonItems (state, emit) {
       text: 'Share',
       actionName: 'share',
       updateLastAction: shareAction
+    },
+    {
+      iconName: 'share',
+      text: 'Make Playlist Public',
+      actionName: 'edit',
+      updateLastAction: editAction
     }
   ]
 
@@ -647,6 +653,18 @@ function menuButtonItems (state, emit) {
     })
 
     document.body.appendChild(dialogEl)
+  }
+
+  /**
+   * @description Redirect user to edit their private playlist
+   * @param {Object} data Action data
+   * @param {String} data.url The playlist's url
+   */
+
+  function editAction (data) {
+    if (data.url.href !== undefined) {
+      window.location.href = `${data.url.href}/edit`
+    }
   }
 
   /**

--- a/packages/menu-button-options-component/index.js
+++ b/packages/menu-button-options-component/index.js
@@ -662,8 +662,12 @@ function menuButtonItems (state, emit) {
    */
 
   function editAction (data) {
-    if (data.url.href !== undefined) {
-      window.location.href = `${data.url.href}/edit`
+    if (
+      data.url.pathname !== undefined &&
+      window.location !== undefined &&
+      window.location.origin !== undefined
+    ) {
+      window.location.href = `${window.location.origin}${data.url.pathname}/edit`
     }
   }
 


### PR DESCRIPTION
For private playlists, `Share` button text becomes `Make Playlist Public`, redirecting the user to the edit playlist page, where they can then make their playlist public.

This closes #107.

<img width="340" alt="Screen Shot 2022-01-06 at 9 55 48 PM" src="https://user-images.githubusercontent.com/60944077/148489729-c240a55c-ccc1-4312-b6b6-2164c3f9f71e.png">