### PR TITLE
 Make removing tracks from playlists more intuitive

### DIFF
--- a/beta/components/forms/trackgroup.js
+++ b/beta/components/forms/trackgroup.js
@@ -19,7 +19,7 @@ const { getAPIServiceClientWithAuth } = require('@resonate/api-service')({
 })
 
 /**
- * Tackgroup form for playlist update
+ * Trackgroup form for playlist update
  */
 
 class TrackgroupForm extends Component {

--- a/beta/components/trackgroups/index.css
+++ b/beta/components/trackgroups/index.css
@@ -36,3 +36,18 @@ input[type="checkbox"] ~ label .icon {
 input[type="checkbox"]:checked ~ label .icon {
   fill: var(--dark-gray);
 }
+
+svg.icon.icon--sm.icon-plus {
+  height: 22px !important;
+  width: 14px !important;
+  border-bottom: 4px solid;
+  padding-bottom: 2px;
+}
+
+svg.icon.icon--sm.icon-plus.fill-black {
+  color: black;
+}
+
+svg.icon.icon--sm.icon-plus.fill-white {
+  color: white;
+}

--- a/packages/menu-button-options-component/index.js
+++ b/packages/menu-button-options-component/index.js
@@ -443,7 +443,7 @@ function menuButtonItems (state, emit) {
     },
     {
       iconName: 'plus',
-      text: 'Add to playlist',
+      text: 'Playlists',
       actionName: 'playlist',
       updateLastAction: addToPlaylistAction
     },

--- a/packages/menu-button-options-component/index.js
+++ b/packages/menu-button-options-component/index.js
@@ -529,7 +529,7 @@ function menuButtonItems (state, emit) {
         const { body: response } = result
 
         const dialogEl = dialog.render({
-          title: 'Add to playlist',
+          title: 'Add/remove from playlist',
           prefix: 'dialog-default dialog--sm',
           content: html`
             <div class="flex flex-column w-100">

--- a/packages/menu-button-options-component/index.js
+++ b/packages/menu-button-options-component/index.js
@@ -529,7 +529,7 @@ function menuButtonItems (state, emit) {
         const { body: response } = result
 
         const dialogEl = dialog.render({
-          title: 'Add/remove from playlist',
+          title: 'Add to/remove from playlist',
           prefix: 'dialog-default dialog--sm',
           content: html`
             <div class="flex flex-column w-100">

--- a/packages/menu-button-options-component/index.js
+++ b/packages/menu-button-options-component/index.js
@@ -529,7 +529,7 @@ function menuButtonItems (state, emit) {
         const { body: response } = result
 
         const dialogEl = dialog.render({
-          title: 'Add to/remove from playlist',
+          title: 'Add or remove from playlists',
           prefix: 'dialog-default dialog--sm',
           content: html`
             <div class="flex flex-column w-100">


### PR DESCRIPTION
Inform user in the `Add to playlist` modal window that they can also use the modal to remove tracks from playlist whatever playlists they so choose.

I tried changing the menu item itself from `Add to playlist` to `Add to/remove from playlist`, but it makes the menu item's text wrap to the next line, making the menu item twice as tall as all of the other menu items, so I left that side of things alone.

<img width="568" alt="Screen Shot 2022-01-16 at 10 11 22 PM" src="https://user-images.githubusercontent.com/60944077/149707048-c54414e1-1cea-4684-ae2b-976ad42b82c5.png">

Perhaps changing the menu item's icon from a plus to a plus/minus (±) would also provide more clarity to the user:
<img width="289" alt="Screen Shot 2022-01-22 at 11 30 32 AM" src="https://user-images.githubusercontent.com/60944077/150649313-12101e99-06e4-4247-8a7a-e56ed32a3cf7.png">

This closes #134.