### PR TITLE
Add the dev guide in the handbook to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 Resonate is an open-source music streaming service run by a cooperative of artists and software developers. 
 
-If you want to know what we're building, or want to get more involved head over to the Platform category on our [forum](https://community.resonate.is/t/development-team/1724).
+If you want to know what we're building or want to get more involved, head over to the Platform category on our [forum](https://community.resonate.is/t/development-team/1724) or read the dev guide in our [handbook](https://community.resonate.is/docs?topic=2262).
 
 If you're looking for a good first task, feel encouraged to take on an un-assigned ['help wanted' issues](https://github.com/resonatecoop/stream/issues). 
 


### PR DESCRIPTION
Since the developer guide was recently published in our [handbook](https://community.resonate.is/docs?topic=2262), we may want to add this to the other resources in the readme to facilitate dev onboarding.


(https://community.resonate.is/docs?topic=2262).
### How the Readme looks _prior_ to adding the handbook link
> If you want to know what we're building, or want to get more involved head over to the Platform category on our [forum](https://community.resonate.is/t/development-team/1724).
<img width="1075" alt="before-adding-handbook-link" src="https://user-images.githubusercontent.com/60944077/149708005-4b06e617-ecab-4333-a67a-b47b1f5ace05.png">


### How the Readme looks _after_ adding the handbook link to the second paragraph
> If you want to know what we're building or want to get more involved, head over to the Platform category on our [forum](https://community.resonate.is/t/development-team/1724) or read the dev guide in our [handbook].
<img width="1084" alt="after-adding-handbook-link" src="https://user-images.githubusercontent.com/60944077/149708006-d6f9e6fb-d336-4693-9ecf-d7b182f6ced5.png">