### PR TITLE
Use `parseISO` to parse date strings

### DIFF
--- a/beta/views/release/index.js
+++ b/beta/views/release/index.js
@@ -4,7 +4,7 @@ const Playlist = require('@resonate/playlist-component')
 const viewLayout = require('../../layouts/trackgroup')
 const { isNode } = require('browser-or-node')
 const MenuButtonOptions = require('@resonate/menu-button-options-component')
-const format = require('date-fns/format')
+const { format, parseISO } = require('date-fns')
 
 /**
  * Display a release or trackgroup (single, lp, ep)
@@ -131,7 +131,7 @@ function renderReleaseDate (date) {
   return html`
     <dl class="flex flex-auto w-100">
       <dt class="f5 lh-copy b">Year</dt>
-      <dd class="ma0 fw1 f5 lh-copy pl4 flex flex-auto">${format(date, 'yyyy')}</dd>
+      <dd class="ma0 fw1 f5 lh-copy pl4 flex flex-auto">${format(parseISO(date), 'yyyy')}</dd>
     </dl>
   `
 }


### PR DESCRIPTION
Using `parseISO` to resolve errors.

It appears that `date-fns/formatISO` is affected by some timezone issues: https://github.com/date-fns/date-fns/issues/2151. I noticed that in `beta/views/library/history.js`, we're importing `date-fns/formatISO` and using that to parse ISO date strings. I didn't change those though. I know [timezones](https://community.resonate.is/t/wrong-release-year-shown-in-player-when-date-is-01-january/2224/3) have been an issue in the display of these release dates.

Closes #145.