### PR TITLE
Add Developer Guide to top of Readme & Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing!
+Thanks for your interest in contributing! Please see the [Developer Guide](https://community.resonate.is/docs?topic=2262) in our [Resonate Handbook](https://community.resonate.is/docs) for a clear overview of all things development related.
 
 There are many ways to contribute:
 - Refactoring code

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@
       Beta app
     </a>
     <span> | </span>
-    <a href="https://github.com/resonatecoop/stream2own/blob/master/CONTRIBUTING.md">
-      Contributing
-    </a>
-    <span> | </span>
     <a href="https://www.twitter.com/resonatecoop/">
       Twitter
     </a>
     <span> | </span>
-    <a href="https://resonate.is/contact-us/join-developer-forum/">
-      Developer forum
+    <a href="https://github.com/resonatecoop/stream2own/blob/master/CONTRIBUTING.md">
+      Contributing
+    </a>
+    <span> | </span>
+    <a href="https://community.resonate.is/docs?topic=2262">
+      Developer Guide
     </a>
   </h3>
 </div>
@@ -39,11 +39,11 @@
   </a>
 </div>
 
-Resonate is an open-source music streaming service run by a cooperative of artists and software developers. 
+Resonate is an open-source music streaming service run by a cooperative of artists and software developers.
 
-If you want to know what we're building or want to get more involved, head over to the Platform category on our [forum](https://community.resonate.is/t/development-team/1724) or read the dev guide in our [handbook](https://community.resonate.is/docs?topic=2262).
+If you want to know what we're building or want to get more involved, head over to the Platform category on our [forum](https://community.resonate.is/t/development-team/1724) or read the [Developer Guide](https://community.resonate.is/docs?topic=2262) in our [Resonate Handbook](https://community.resonate.is/docs).
 
-If you're looking for a good first task, feel encouraged to take on an un-assigned ['help wanted' issues](https://github.com/resonatecoop/stream/issues). 
+If you're looking for a good first task, feel encouraged to take on an un-assigned ['help wanted' issues](https://github.com/resonatecoop/stream/issues).
 
 Are you building something using the Resonate [API](#api) and would like to request a change? Resonate welcomes #proposals in the [Co-Operation section of the forum](https://community.resonate.is/c/66).
 


### PR DESCRIPTION
Per discussion [here](https://community.resonate.is/t/easy-way-to-follow-progress-plans-challenges/2302/10) with @fgblomqvist, these changes add links to the Developer Guide to the very top of the Readme and to the Contributing page.

Also, these changes _remove_ the link to the [Developer forum](https://resonate.is/contact-us/join-developer-forum/), which links to a form that appears to obsolete. (Please correct me if I'm wrong about this and I'm happy to re-add/retain that link.)

For comparison, here are the various pages, viewed before and after the changes performed by this pull request:

### Readme
[Readme.md as it is currently](https://github.com/resonatecoop/stream#readme):
<img width="1427" alt="Screen Shot 2022-01-21 at 7 53 51 AM" src="https://user-images.githubusercontent.com/60944077/150538881-a19c85e0-0d22-44a1-9d00-b2550c956f46.png">

Readme.md after these changes:
<img width="1403" alt="Screen Shot 2022-01-21 at 7 34 27 AM" src="https://user-images.githubusercontent.com/60944077/150536365-f5b44d02-6fae-442a-bcc0-ce17f729fc10.png">

### Contributing
[Contributing.md as it is currently](https://github.com/resonatecoop/stream/blob/master/CONTRIBUTING.md):
<img width="1403" alt="Screen Shot 2022-01-21 at 7 54 15 AM" src="https://user-images.githubusercontent.com/60944077/150538916-707024ff-7218-4417-9df5-8dbebeb75562.png">

Contributing.md after these changes:
<img width="1389" alt="Screen Shot 2022-01-21 at 7 33 32 AM" src="https://user-images.githubusercontent.com/60944077/150536364-5cc156fe-154f-4fba-b6be-c7b34ce6d6c6.png">

