### PR TITLE
Fixed selector in beta/header/index.css 

### DIFF
--- a/beta/components/header/index.css
+++ b/beta/components/header/index.css
@@ -1,4 +1,4 @@
-ul.menu li.active::after {
+ul[role="menu"] li.active::after {
   position: absolute;
   content: "";
   width: 4px;
@@ -10,7 +10,7 @@ ul.menu li.active::after {
   transform: translate3d(-50%, 0, 0);
 }
 
-ul.menu.flex-column li.active::after {
+ul[role="menu"].flex-column li.active::after {
   left: 1rem;
   top: 50%;
   transform: translate3d(0, -50%, 0);

--- a/beta/components/header/index.js
+++ b/beta/components/header/index.js
@@ -182,7 +182,7 @@ class Header extends Component {
       return html`
         <nav role="navigation" aria-label="Main navigation" class="dropdown-navigation flex w-100 flex-auto justify-end-l">
           <ul class="flex list ma0 pa0 w-100 w-90-l justify-around items-center mr3" role="menu">
-            <li class="flex flex-auto w-100 justify-center relative${/artists|labels/.test(this.state.href) ? ' active' : ''}" role="menuitem">
+            <li class="flex flex-auto w-100 justify-center relative${/artists|labels|tracks|releases/.test(this.state.href) ? ' active' : ''}" role="menuitem">
               <a href="/artists" class="dn db-l link near-black near-black--light near-white--dark pv2 ph3">Browse</a>
               <button class="db dn-l bg-transparent bn near-black near-black--light near-white--dark pa0" title="Open Browse Menu" onclick=${(e) => this.local.machine.emit('browse:toggle')} >
                 <span class="flex justify-center items-center">
@@ -405,10 +405,9 @@ class Header extends Component {
       return html`
         <div class="flex flex-auto items-center w-100 relative">
           <nav class="flex flex-auto w-100">
-            <ul class="menu flex w-100 list ma0 pa0">
+            <ul class="flex w-100 list ma0 pa0" role="menu">
               ${items.map(({ text, href }) => {
                 const active = this.state.href === href
-
                 return html`
                   <li class="flex flex-auto justify-center relative ${active ? 'active' : ''}">
                     <a href=${href} class="link db near-black near-white--dark near-black--light pv2 ph3">${text}</a>

--- a/beta/components/header/index.js
+++ b/beta/components/header/index.js
@@ -184,11 +184,9 @@ class Header extends Component {
           <ul class="flex list ma0 pa0 w-100 w-90-l justify-around items-center mr3" role="menu">
             <li class="flex flex-auto w-100 justify-center relative${/artists|labels|tracks|releases/.test(this.state.href) ? ' active' : ''}" role="menuitem">
               <a href="/artists" class="dn db-l link near-black near-black--light near-white--dark pv2 ph3">Browse</a>
-              <button class="db dn-l bg-transparent bn near-black near-black--light near-white--dark pa0" title="Open Browse Menu" onclick=${(e) => this.local.machine.emit('browse:toggle')} >
-                <span class="flex justify-center items-center">
+              <a href="#" class="db dn-l link near-black near-black--light near-white--dark pv2 ph3" title="Open Browse Menu" onclick=${(e) => this.local.machine.emit('browse:toggle')} >
                   Browse
-                </span>
-              </button>
+              </a>
             </li>
             <li class="flex flex-auto w-100 justify-center relative${this.state.href === '/discover' ? ' active' : ''}" role="menuitem">
               <a href="/discover" class="link db near-black near-black--light near-white--dark pv2 ph3">Discover</a>

--- a/beta/components/header/index.js
+++ b/beta/components/header/index.js
@@ -202,7 +202,7 @@ class Header extends Component {
               `
               : html`<li class="flex flex-auto w-100 justify-center" role="divider"></li>`}
             <li class="${this.state.resolved && !this.state.user.uid ? 'flex' : 'dn'} flex-auto justify-center w-100 grow" role="menuitem">
-              <a class="link pv1 ph3 ttu ba b--mid-gray b--dark-gray--dark db f6 b" href=${AUTH_HREF}>
+              <a class="link pv1 ph3 ttu ba b--mid-gray b--dark-gray--dark db f6 b" href=${AUTH_HREF} >
                 Log In
               </a>
             </li>

--- a/beta/components/header/index.js
+++ b/beta/components/header/index.js
@@ -184,7 +184,7 @@ class Header extends Component {
           <ul class="flex list ma0 pa0 w-100 w-90-l justify-around items-center mr3" role="menu">
             <li class="flex flex-auto w-100 justify-center relative${/artists|labels|tracks|releases/.test(this.state.href) ? ' active' : ''}" role="menuitem">
               <a href="/artists" class="dn db-l link near-black near-black--light near-white--dark pv2 ph3">Browse</a>
-              <a href="#" class="db dn-l link near-black near-black--light near-white--dark pv2 ph3" title="Open Browse Menu" onclick=${(e) => this.local.machine.emit('browse:toggle')} >
+              <a href="javascript:;" class="db dn-l link near-black near-black--light near-white--dark pv2 ph3" title="Open Browse Menu" onclick=${(e) => this.local.machine.emit('browse:toggle')} >
                   Browse
               </a>
             </li>
@@ -195,11 +195,9 @@ class Header extends Component {
               ? html`
                 <li class="flex flex-auto w-100 justify-center relative${this.state.href.includes('library') ? ' active' : ''}" role="menuitem">
                   <a href="/u/${this.state.user.uid}/library/favorites" class="link dn db-l near-black near-black--light near-white--dark pv2 ph3">Library</a>
-                  <button class="db dn-l bg-transparent bn near-black near-black--light near-white--dark pa0" title="Open Library Menu" onclick=${(e) => this.local.machine.emit('library:toggle')} >
-                    <span class="flex justify-center items-center">
+                  <a href="javascript:;" class="db dn-l link near-black near-black--light near-white--dark pv2 ph3" title="Open Library Menu" onclick=${(e) => this.local.machine.emit('library:toggle')} >
                       Library
-                    </span>
-                  </button>
+                  </a>
                 </li>
               `
               : html`<li class="flex flex-auto w-100 justify-center" role="divider"></li>`}

--- a/beta/components/header/index.js
+++ b/beta/components/header/index.js
@@ -413,7 +413,6 @@ class Header extends Component {
         </div>
       `
     }
-  }
 
   renderSearch () {
     const search = {

--- a/beta/layouts/browse/index.js
+++ b/beta/layouts/browse/index.js
@@ -25,7 +25,7 @@ module.exports = (view) => {
           </div>
           <div class="flex flex-row flex-auto w-100">
             <nav role="navigation" aria-label="Browse navigation" class="dn db-l">
-              <ul class="sticky list menu ma0 pa0 flex flex-column justify-around sticky z-999" style="top:3rem">
+              <ul class="sticky list menu ma0 pa0 flex flex-column justify-around sticky z-999" style="top:3rem" role="menu">
                 ${items.map(({ text, href, title }) => {
                   const attrs = {
                     class: 'link b near-black near-black--light gray--dark db dim pv2 ph4 w-100',

--- a/beta/layouts/library/index.js
+++ b/beta/layouts/library/index.js
@@ -42,7 +42,7 @@ function LayoutLibrary (view) {
         </div>
         <div class="flex flex-row flex-auto w-100">
           <nav role="navigation" aria-label="Browse navigation" class="dn db-l ml5-l">
-            <ul class="sticky list menu ma0 pa0 flex flex-column justify-around sticky z-999" style="top:3rem">
+            <ul class="sticky list menu ma0 pa0 flex flex-column justify-around sticky z-999" style="top:3rem" role="menu">
               ${items.map(({ name, title, href }) => {
                 const attrs = {
                   class: 'link b near-black near-black--light gray--dark db dim pv2 ph4 w-100',

--- a/beta/layouts/profile/index.js
+++ b/beta/layouts/profile/index.js
@@ -61,7 +61,7 @@ function LayoutProfile (view) {
           </div>
           <div class="flex flex-row">
             <nav role="navigation" aria-label="Profile navigation" class="dn db-l">
-              <ul class="sticky list menu ma0 pa0 flex flex-column justify-around sticky z-999" style="top:6rem">
+              <ul class="sticky list menu ma0 pa0 flex flex-column justify-around sticky z-999" style="top:6rem" role="menu">
                 ${links.filter(({ kinds = [], routes = [] }) => {
                   if (!kinds.length) return true
                   if (!kinds.includes(kind)) return false

--- a/beta/layouts/search/index.js
+++ b/beta/layouts/search/index.js
@@ -65,7 +65,7 @@ function LayoutSearch (view) {
             </div>
           </div>
           <nav role="navigation" aria-label="Search navigation" class="dn db-l">
-            <ul class="sticky list menu ma0 pa0 flex flex-column justify-around z-999" style="top:3rem">
+            <ul class="sticky list menu ma0 pa0 flex flex-column justify-around z-999" style="top:3rem" role="menu">
               ${links.map(({ kind, text }) => {
                 const url = new URL(state.href, 'http://localhost')
 


### PR DESCRIPTION
This is to fix #150 

The dot to show which page was currently active was not shown because the CSS was looking for ul with `class="menu"` while the component had the ul with `role="menu"` so this commit changes the class selector to a role selector.