### PR TITLE
Fix play counts on label page

### DIFF
--- a/beta/components/discography/index.js
+++ b/beta/components/discography/index.js
@@ -104,14 +104,31 @@ class Discography extends Component {
 
               const cid = `${this._name}-album-playlist-${index}`
 
+              let albumCover = html`
+                <div role="img" style="background:url(${cover || imagePlaceholder(400, 400)}) no-repeat;"
+                     class="aspect-ratio--1x1 bg-dark-gray bg-center cover z-1">
+                </div>
+              `
+              let albumTitle = title;
+
+              // Make the album cover and title a link if a slug was provided
+              if (slug) {
+                const albumLink = `/artist/${creatorId}/release/${slug}`;
+
+                albumCover = html`
+                  <a class="db" href="${albumLink}">
+                    ${albumCover}
+                  </a>
+                `;
+
+                albumTitle = html`<a class="link" href="${albumLink}">${albumTitle}</a>`
+              }
+
               return html`
                 <div class="flex flex-column flex-auto mb6">
                   <article class="flex flex-column flex-row-ns flex-auto items-start">
                     <div class="flex flex-column mw4-ns mw5-l w-100 mb5 mb0-ns relative">
-                      <a class="db aspect-ratio aspect-ratio--1x1 bg-dark-gray" href="/artist/${user.id}/release/${slug}">
-                        <span role="img" style="background:url(${cover || imagePlaceholder(400, 400)}) no-repeat;" class="bg-center cover aspect-ratio--object z-1">
-                        </span>
-                      </a>
+                      ${albumCover}
                       <div class="flex items-center absolute z-1 right-0 mr1-ns" style="top:100%">
                         ${this.state.cache(MenuButtonOptions, `menu-button-options-discography-item-${slug}`).render({
                           items: [], // no custom items yet
@@ -131,7 +148,7 @@ class Discography extends Component {
                       <header>
                         <div class="flex flex-column">
                           <h3 class="ma0 lh-title f3 fw4 normal">
-                            <a class="link" href="/artist/${creatorId}/release/${slug}">${title}</a>
+                            ${albumTitle}
                           </h3>
                           <div>
                             ${displayArtist}

--- a/beta/components/discography/index.js
+++ b/beta/components/discography/index.js
@@ -98,7 +98,6 @@ class Discography extends Component {
                 title,
                 items = [],
                 cover,
-                user = {},
                 slug
               } = item
 
@@ -108,15 +107,15 @@ class Discography extends Component {
                 <div role="img" style="background:url(${cover || imagePlaceholder(400, 400)}) no-repeat;"
                      class="aspect-ratio--1x1 bg-dark-gray bg-center cover z-1">
                 </div>
-              `;
-              let albumTitle = title;
+              `
+              let albumTitle = title
 
               // Make the album cover and title a link if a slug was provided
               if (slug) {
-                const albumLink = `/artist/${creatorId}/release/${slug}`;
+                const albumLink = `/artist/${creatorId}/release/${slug}`
 
-                albumCover = html`<a class="db" href="${albumLink}">${albumCover}</a>`;
-                albumTitle = html`<a class="link" href="${albumLink}">${albumTitle}</a>`;
+                albumCover = html`<a class="db" href="${albumLink}">${albumCover}</a>`
+                albumTitle = html`<a class="link" href="${albumLink}">${albumTitle}</a>`
               }
 
               return html`

--- a/beta/components/discography/index.js
+++ b/beta/components/discography/index.js
@@ -108,20 +108,15 @@ class Discography extends Component {
                 <div role="img" style="background:url(${cover || imagePlaceholder(400, 400)}) no-repeat;"
                      class="aspect-ratio--1x1 bg-dark-gray bg-center cover z-1">
                 </div>
-              `
+              `;
               let albumTitle = title;
 
               // Make the album cover and title a link if a slug was provided
               if (slug) {
                 const albumLink = `/artist/${creatorId}/release/${slug}`;
 
-                albumCover = html`
-                  <a class="db" href="${albumLink}">
-                    ${albumCover}
-                  </a>
-                `;
-
-                albumTitle = html`<a class="link" href="${albumLink}">${albumTitle}</a>`
+                albumCover = html`<a class="db" href="${albumLink}">${albumCover}</a>`;
+                albumTitle = html`<a class="link" href="${albumLink}">${albumTitle}</a>`;
               }
 
               return html`

--- a/beta/stores/labels.js
+++ b/beta/stores/labels.js
@@ -577,7 +577,7 @@ async function fetchLabelReleases(labelID, pageNumber) {
 async function fetchLabelArtists (labelID, pageNumber) {
   const client = await getAPIServiceClient('labels')
   const { body } = await client.getLabelArtists({
-    labelID,
+    id: labelID,
     limit: 20,
     page: pageNumber
   })

--- a/beta/stores/labels.js
+++ b/beta/stores/labels.js
@@ -179,7 +179,7 @@ function labels () {
         await Promise.all([
           getLabelDiscography(labelID, pageNumber),
           getLabelAlbums(labelID, pageNumber),
-          getLabelArtists(labelID, pageNumber),
+          getLabelArtists(labelID, pageNumber)
         ])
       } catch (err) {
         state.label.notFound = err.status === 404
@@ -193,12 +193,12 @@ function labels () {
     emitter.on('route:label/:id/releases', () => {
       const labelID = Number(state.params.id)
       const pageNumber = state.query.page ? Number(state.query.page) : 1
-      getLabelDiscography(labelID, pageNumber);
+      getLabelDiscography(labelID, pageNumber)
     })
     emitter.on('route:label/:id/artists', () => {
       const labelID = Number(state.params.id)
       const pageNumber = state.query.page ? Number(state.query.page) : 1
-      getLabelArtists(labelID, pageNumber);
+      getLabelArtists(labelID, pageNumber)
     })
 
     emitter.once('prefetch:labels', async () => {
@@ -299,10 +299,10 @@ function labels () {
       machine.emit('start')
 
       try {
-        const data = await fetchLabelReleases(labelID, pageNumber);
-        state.label.discography.items = data.albums;
-        state.label.discography.count = data.totalCount;
-        state.label.discography.numberOfPages = data.numberOfPages;
+        const data = await fetchLabelReleases(labelID, pageNumber)
+        state.label.discography.items = data.albums
+        state.label.discography.count = data.totalCount
+        state.label.discography.numberOfPages = data.numberOfPages
 
         if (state.user.uid) {
           state.label.discography.items = await updatePlayCounts(state.user.token, state.label.discography.items)
@@ -348,10 +348,10 @@ function labels () {
       machine.emit('start')
 
       try {
-        const data = await fetchLabelAlbums(labelID, pageNumber);
-        state.label.albums.items = data.albums;
-        state.label.albums.count = data.totalCount;
-        state.label.albums.numberOfPages = data.numberOfPages;
+        const data = await fetchLabelAlbums(labelID, pageNumber)
+        state.label.albums.items = data.albums
+        state.label.albums.count = data.totalCount
+        state.label.albums.numberOfPages = data.numberOfPages
 
         if (state.user.uid) {
           state.label.albums.items = await updatePlayCounts(state.user.token, state.label.albums.items)
@@ -390,16 +390,16 @@ function labels () {
         return
       }
 
-      const loaderTimeout = setLoaderTimeout(machine, 500);
+      const loaderTimeout = setLoaderTimeout(machine, 500)
 
       machine.emit('request:start')
 
       try {
-        const data = await fetchLabelArtists(labelID, pageNumber);
+        const data = await fetchLabelArtists(labelID, pageNumber)
 
-        state.label.artists.items = data.artists;
-        state.label.artists.count = data.totalCount;
-        state.label.artists.numberOfPages = data.numberOfPages;
+        state.label.artists.items = data.artists
+        state.label.artists.count = data.totalCount
+        state.label.artists.numberOfPages = data.numberOfPages
 
         machine.emit('request:resolve')
         setMeta()
@@ -470,7 +470,7 @@ function labels () {
  * @param {Album[]} albums
  * @returns {Promise<Album[]>} A copy of the list of albums with their play counts updated.
  */
-async function updatePlayCounts(userToken, albums) {
+async function updatePlayCounts (userToken, albums) {
   // Get a list of all unique track IDs
   const ids = [...new Set(
     albums.map((album) => {
@@ -511,7 +511,7 @@ async function updatePlayCounts(userToken, albums) {
  * @param {number} pageNumber
  * @returns {Promise<AlbumFetchResponse>} Returns the albums in the standardized "Album" format.
  */
-async function fetchLabelAlbums(labelID, pageNumber) {
+async function fetchLabelAlbums (labelID, pageNumber) {
   const client = await getAPIServiceClient('labels')
   const result = await client.getLabelAlbums({
     id: labelID,
@@ -540,7 +540,7 @@ async function fetchLabelAlbums(labelID, pageNumber) {
   return {
     albums: albums,
     totalCount: result.body.count,
-    numberOfPages: result.body.numberOfPages || 1,
+    numberOfPages: result.body.numberOfPages || 1
   }
 }
 
@@ -551,7 +551,7 @@ async function fetchLabelAlbums(labelID, pageNumber) {
  * @param {number} pageNumber
  * @returns {Promise<AlbumFetchResponse>} Returns the releases in the standardized "Album" format.
  */
-async function fetchLabelReleases(labelID, pageNumber) {
+async function fetchLabelReleases (labelID, pageNumber) {
   const client = await getAPIServiceClient('labels')
   const result = await client.getLabelReleases({
     id: labelID,
@@ -578,7 +578,7 @@ async function fetchLabelReleases(labelID, pageNumber) {
   return {
     albums: albums,
     totalCount: result.body.count,
-    numberOfPages: result.body.numberOfPages || 1,
+    numberOfPages: result.body.numberOfPages || 1
   }
 }
 
@@ -600,6 +600,6 @@ async function fetchLabelArtists (labelID, pageNumber) {
   return {
     artists: body.data,
     totalCount: body.count || 0,
-    numberOfPages: body.numberOfPages || 1,
+    numberOfPages: body.numberOfPages || 1
   }
 }

--- a/beta/stores/labels.js
+++ b/beta/stores/labels.js
@@ -17,12 +17,27 @@ module.exports = labels
 /**
  * @typedef Album
  * @property [boolean] various
- * @property {object[]} items
- * @property {number} items[].count
- * @property {number} items[].fav
- * @property {object[]} items[].track_group
- * @property {string} items[].url
- * @property {object} items[].track
+ * @property {TrackListItem[]} items
+ */
+
+/**
+ * @typedef TrackListItem
+ * @property {number} count
+ * @property {number} fav
+ * @property {TrackGroup[]} track_group
+ * @property {string} url
+ * @property {Track} track
+ */
+
+/**
+ * @typedef Track
+ * @property {number} id
+ */
+
+/**
+ * @typedef TrackGroup
+ * @property {string} title
+ * @property {string} display_artist
  */
 
 /**
@@ -452,8 +467,8 @@ function labels () {
  * Updates the play counts on all the tracks in the list of albums with the latest data from the API.
  *
  * @param {string} userToken
- * @param {object[]} albums
- * @returns {Promise<object[]>} A copy of the list of albums with their play counts updated.
+ * @param {Album[]} albums
+ * @returns {Promise<Album[]>} A copy of the list of albums with their play counts updated.
  */
 async function updatePlayCounts(userToken, albums) {
   // Get a list of all unique track IDs
@@ -482,9 +497,9 @@ async function updatePlayCounts(userToken, albums) {
   // Update all the tracks on each album with its play count and return the modified list of albums
   return albums.map((album) => ({
     ...album,
-    items: album.items.map((trackItem) => ({
-      ...trackItem,
-      count: counts[trackItem.track.id] || 0
+    items: album.items.map((trackListItem) => ({
+      ...trackListItem,
+      count: counts[trackListItem.track.id] || 0
     }))
   }))
 }
@@ -508,17 +523,17 @@ async function fetchLabelAlbums(labelID, pageNumber) {
   const albums = result.body.data.map((album) => ({
     ...album,
     various: true,
-    items: album.items.map((trackItem) => ({
+    items: album.items.map((trackListItem) => ({
       count: 0,
       fav: 0,
       track_group: [
         {
-          title: trackItem.album,
-          display_artist: trackItem.artist
+          title: trackListItem.album,
+          display_artist: trackListItem.artist
         }
       ],
-      track: trackItem,
-      url: trackItem.url || `https://api.resonate.is/v1/stream/${trackItem.id}`
+      track: trackListItem,
+      url: trackListItem.url || `https://api.resonate.is/v1/stream/${trackListItem.id}`
     }))
   }))
 
@@ -546,17 +561,17 @@ async function fetchLabelReleases(labelID, pageNumber) {
 
   const albums = result.body.data.map((album) => ({
     ...album,
-    items: album.items.map((trackItem) => ({
+    items: album.items.map((trackListItem) => ({
       count: 0,
       fav: 0,
       track_group: [
         {
-          title: trackItem.track.album,
-          display_artist: trackItem.track.artist
+          title: trackListItem.track.album,
+          display_artist: trackListItem.track.artist
         }
       ],
-      track: trackItem.track,
-      url: trackItem.track.url || `https://api.resonate.is/v1/stream/${trackItem.track.id}`
+      track: trackListItem.track,
+      url: trackListItem.track.url || `https://api.resonate.is/v1/stream/${trackListItem.track.id}`
     }))
   }))
 

--- a/beta/views/labels/index.js
+++ b/beta/views/labels/index.js
@@ -1,6 +1,6 @@
 const { isNode } = require('browser-or-node')
 const html = require('choo/html')
-const Labels = require('../../components/profiles')
+const Profiles = require('../../components/profiles')
 const Pagination = require('../../components/pagination')
 const subView = require('../../layouts/browse')
 
@@ -11,7 +11,7 @@ function renderLabels (state, emit) {
 
   return html`
     <section id="labels" class="flex flex-column flex-auto w-100">
-      ${state.cache(Labels, 'labels').render({
+      ${state.cache(Profiles, 'labels').render({
         items: state.labels.items
       })}
       ${state.cache(Pagination, 'labels-pagination').render({


### PR DESCRIPTION
Closes #153.

Changes:
* Refactor the various `getX` functions to consist of a standardized `fetchX` function along with the error handling + loading logic.
* Introduce some basic JSDoc types (for now) to make it clear what data gets passed in/out.
  * These can easily be converted to TS types later if we want. All competent IDEs should be able to provide type hints using these comments at least.
* Ensure VA albums are not clickable (i.e. they're not links)

Notes:
I took some liberty when refactoring, trying to follow best practices as I know them and to reduce reading complexity (such as using the spread syntax instead of object.assign). Please let me know if there is any particular coding style I have used that is not deemed favorable by this project.

The part that is potentially left is to do yet another iteration so that the `getLabelDiscography` and `getLabelAlbums` functions can use the same/similar flow. As can be seen now, they are both practically identical beyond which state they read/set and which fetch function they use. I wasn't sure how to best combine them since I am not sure what the `state.cache` and `state.components`/`machine` stuff is/how it works. If the loading logic can be combined in a good way, it should be simple enough to combine these two functions.