### PR TITLE
Now Playing Track Title and Artist Name are Page Title

### DIFF
--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -237,6 +237,11 @@ class Player extends Nanocomponent {
       })
 
       sound.on('timeupdate', (currentTime) => {
+        const nowPlaying = `${this.local.track.artist} · ${this.local.track.title}`
+        if (document.title !== nowPlaying) {
+          document.title = nowPlaying
+        }
+
         this.local.currentTime = currentTime
         this.local.progress = 100 * currentTime / sound.audio.duration
 


### PR DESCRIPTION
Per [this post](https://community.resonate.is/t/minimal-mobile-stream-app/2613/21), iOS is still not reporting Artist Name and Track Title to the Now Playing and Control Center widgets and is printing the title. To match what many industry web players already do, these changes modify the page's title to match the currently playing track, regardless of where the user browses to.

<img width="1064" alt="Screen Shot 2022-02-21 at 7 48 54 PM" src="https://user-images.githubusercontent.com/60944077/155048437-3399ff0c-c208-479b-a658-214fbb181667.png">
