### PR TITLE
Inform users that cookies are currently necessary to login

### DIFF
--- a/beta/src/components/forms/login.js
+++ b/beta/src/components/forms/login.js
@@ -76,11 +76,14 @@ class Login extends Component {
           type: 'password',
           placeholder: 'Password',
           help: html`
-            <div class="flex justify-end">
-              <a href="https://resonate.is/password-reset/" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
-                Forgot your password?
-              </a>
-            </div>
+          <div class="flex">
+            <a class="justify-beginning" href="https://stream.resonate.coop/settings" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
+              Trouble logging in? Enable cookies.
+            </a>
+            <a class="justify-end" href="https://resonate.is/password-reset/" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
+              Forgot your password?
+            </a>
+          </div>
           `
         }
       ],

--- a/beta/src/components/forms/login.js
+++ b/beta/src/components/forms/login.js
@@ -76,14 +76,18 @@ class Login extends Component {
           type: 'password',
           placeholder: 'Password',
           help: html`
-          <div class="flex">
-            <a class="justify-beginning" href="https://stream.resonate.coop/settings" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
-              Trouble logging in? Enable cookies.
-            </a>
-            <a class="justify-end" href="https://resonate.is/password-reset/" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
-              Forgot your password?
-            </a>
-          </div>
+            <div>
+              <p align="right" style="margin-top:0">
+                <a href="https://resonate.is/password-reset/" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
+                  Forgot your password?
+                </a>
+              </p>
+              <p align="left" style="margin-top:-5ex;margin-bottom:0;">
+                <a href="/settings" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
+                  Trouble logging in?
+                </a>
+              </p>
+            </div>
           `
         }
       ],

--- a/beta/src/views/settings/index.js
+++ b/beta/src/views/settings/index.js
@@ -20,6 +20,8 @@ function renderSettings (state, emit) {
     size: 'none'
   })
 
+  const cookieConsentGranted = state.cookieConsentStatus === 'allow'
+
   return html`
     <section id="app-settings" class="flex flex-column ph4 mt3">
       <div class="bg-light-gray bg-light-gray--light bg-transparent--dark ba b--gray b--gray--light b--near-black--dark mb3 pa3">
@@ -35,8 +37,16 @@ function renderSettings (state, emit) {
         <fieldset class="pa0 ma0 bn">
           <legend class="f3 lh-title ma0">Cookie consent</legend>
           <div class="mt2 mb4">
-            <label for="cache" class="f5 lh-copy db mb2 required">${state.cookieConsentStatus === 'allow' ? 'Cookies are allowed' : 'Cookies are disabled'}</label>
+            <label for="cache" class="f5 lh-copy db mb2 required">Cookies are ${cookieConsentGranted ? 'allowed' : 'disabled'}</label>
             ${cookiesOptions}
+            ${!cookieConsentGranted
+              ? html`
+              <br>
+              <br>
+              <p class="lh-copy f5 b">Disable functional cookies only if you expect Resonate to not persist your session.</p>
+              `
+              : ''
+              }
           </div>
         </fieldset>
       </div>


### PR DESCRIPTION
These changes add a link to https://stream.resonate.coop/settings to the left of the Password Reset link. This link can probably be removed once users who have disallowed cookies can login via alternate means (per discussion with @auggod).

### New login link
<img width="1158" alt="login screen with new link" src="https://user-images.githubusercontent.com/60944077/155654142-21b3f0ed-f964-4c58-8ba5-3f2a2c8d7f21.png">

### Settings page for users with enabled cookies
<img width="1073" alt="Screen Shot 2022-02-24 at 10 31 18 PM" src="https://user-images.githubusercontent.com/60944077/155654152-e7212014-87b8-4163-b998-5903221a63c7.png">

### Settings page with cookie disclaimer for users with disabled cookies
<img width="1158" alt="Screen Shot 2022-02-24 at 10 29 20 PM" src="https://user-images.githubusercontent.com/60944077/155654150-f0932c46-8aa9-4930-b461-356d6636eb66.png">

This closes #178.