### PR TITLE
Theme defaults to Auto instead of Light

### DIFF
--- a/beta/src/components/theme-switcher/index.js
+++ b/beta/src/components/theme-switcher/index.js
@@ -82,7 +82,10 @@ class ThemeSwitcher extends Component {
   }
 
   load (el) {
-    this.local.auto = localStorage !== null && !!localStorage.getItem('color-scheme-auto')
+    this.local.auto = localStorage !== null && 'color-scheme' in localStorage
+      ? !!localStorage.getItem('color-scheme-auto')
+      : true
+
     this.rerender()
 
     if (


### PR DESCRIPTION
For new users, when they first visit the player, the theme default was Light, even for users using devices with dark color preferences. These (very simple) changes now default Auto to be on, so user device preferences will now be respected even if they aren't logged in (because login is currently required to change theme preferences).

![Screen Shot 2022-02-24 at 5 36 09 PM](https://user-images.githubusercontent.com/60944077/155625400-11e3cf77-cfb1-4ec7-b3aa-2245046167cb.png)

These changes will also benefit [stream-app](https://github.com/peterklingelhofer/stream-app) users visiting for the first time. The status bar color goes off the user's device color-preferences, so users visiting the app for the first time with a dark-mode device would have a dark status bar and a light stream player. These changes resolve this contradiction.

This closes #181.