### PR TITLE
Fix nanohtml imports

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -14,7 +14,7 @@
     "dev:assets": "run-p \"build:assets:src -- --watch\" \"build:assets:packagejson -- --watch\"",
     "dev:jalla": "cd build && jalla start index.js --sw sw.js --watch",
     "audit:npm": "npm audit",
-    "start": "NODE_ENV=production run-s build:ts build:assets:* && cd build && jalla serve index.js --sw sw.js --dir ../dist",
+    "start": "NODE_ENV=production cd build && jalla serve index.js --sw sw.js --dir ../dist",
     "test": "run-s test:lint test:deps",
     "test:lint": "eslint .",
     "test:deps": "dependency-check ./src/index.js -i nanobus -i @resonate/tachyons --no-dev",

--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -1,4 +1,3 @@
-import html from 'choo/html'
 import Component from 'choo/component'
 import icon from '@resonate/icon-element'
 import nanostate from 'nanostate'
@@ -18,6 +17,8 @@ import { background as bg } from '@resonate/theme-skins'
 import TAGS from '../../lib/tags'
 import Nanobus from 'nanobus'
 import { AppState } from '../../types'
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const html = require('choo/html')
 
 const log = logger('header')
 

--- a/beta/src/stores/tracks.ts
+++ b/beta/src/stores/tracks.ts
@@ -2,7 +2,6 @@ import logger from 'nanologger'
 import setTitle from '../lib/title'
 import copy from 'clipboard-copy'
 import Dialog from '@resonate/dialog-component'
-import html from 'choo/html'
 import setPlaycount from '../lib/update-counter'
 import button from '@resonate/button'
 import link from '@resonate/link-element'
@@ -13,6 +12,8 @@ import APIService from '@resonate/api-service'
 import { calculateRemainingCost, formatCredit } from '@resonate/utils'
 import { AppState } from '../types'
 import type { TrackAPIResponse, TracksFindProps } from './tracks.types'
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const html = require('choo/html')
 
 const log = logger('store:tracks')
 

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -1,7 +1,8 @@
-import html from 'nanohtml'
 import icon from '@resonate/icon-element'
 import { background as bg } from '@resonate/theme-skins'
 import classNames from 'classnames'
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const html = require('nanohtml')
 
 interface ButtonProps {
   prefix?: string


### PR DESCRIPTION
When building the final bundle, nanohtml relies on a custom browerify transform to do some "magic". However, the transform doesn't handle more complex imports correctly and therefore fails with TS-built code. It is detailed here: https://github.com/choojs/nanohtml/issues/152. It does not seem to be properly fixed, despite being marked as such.

This PR works around the issue by reverting the nanohtml imports to the old require syntax. I also removed the build step from the `start` script since you will need to have run `npm run build` before running `npm start` anyway.