### PR TITLE
Handle cookie denial for logged out users

### DIFF
--- a/beta/src/stores/app.js
+++ b/beta/src/stores/app.js
@@ -253,7 +253,9 @@ function app () {
       delete state.clientId
 
       if (process.env.AUTH_API === 'v2') {
-        window.location = '/api/v2/user/logout'
+        if (state.user.uid !== undefined) {
+          window.location = '/api/v2/user/logout'
+        }
       } else {
         // handle v1 logout
         await state.api.auth.logout()


### PR DESCRIPTION
To avoid receiving a 401, `Missing required access token error` with the new auth system, we skip the redirect if `state.user.uid !== undefined`.

We could also address this in [consent.js](https://github.com/resonatecoop/stream/blob/f054ba30d721c76dcb4c19cec8fda811167e8b2f/beta/src/stores/consent.js#L28) by not calling logout if the user isn't logged in. I wasn't sure if there were other aspects of the logout function that should still run just for cleanup's sake, so I added the if later in the logic chain.

This closes #185.