### PR TITLE
feat: add join now button for non-authed visitors

### DIFF
--- a/beta/src/views/discover/index.js
+++ b/beta/src/views/discover/index.js
@@ -13,10 +13,23 @@ function renderDiscover (state, emit) {
 
   return html`
     <section id="discover" class="flex flex-column flex-auto w-100 ph3 ph4-ns">
-      <h2 class="lh-title f3 fw1">
-        The co-operative music streaming platform.<br>
-        Owned and run by members.
-      </h2>
+      <div class="mv4">
+        <h2 class="di mr3 lh-title f3 fw1 v-mid">
+          The co-operative music streaming platform.<br />
+          Owned and run by members.
+        </h2>
+
+        ${!state.user.uid
+          ? html`
+              <a
+                class="link pv2 ph3 ttu ba b--mid-gray b--dark-gray--dark f6 b"
+                href="https://resonate.coop/join"
+              >
+                Join now
+              </a>
+            `
+          : null}
+      </div>
 
       <ul class="list ma0 pa0 pv2 flex flex-wrap mw7">
         ${tags.map(tag => {


### PR DESCRIPTION
### Adds a „join now” button for non-authed visitors on the discovery page. #116 

For now the url points to ”https://resonate.coop/join” like in the footer or login page.

<img src="https://user-images.githubusercontent.com/3693161/156559331-ddaffd57-3e41-4ee6-8291-29bfddccd50c.png" alt="Screenshot on mobile device" width="200" />

<img src="https://user-images.githubusercontent.com/3693161/156559315-56dd8ef4-bfc9-478e-b678-66a5aa03385f.png" alt="Screenshot on desktop device" width="485" />
