### PR TITLE
Login to listen in full is clickable link

### DIFF
--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -330,7 +330,7 @@ class Player extends Nanocomponent {
     return html`
       <div class="player-component flex flex-column h-100">
         ${!isAuthenticated
-          ? html`<a class="flex flex-row w-100 justify-center bb b--light-silver no-underline glow" href="/login" target="_blank" rel="noopener noreferer">Log in to listen to full song</a>`
+          ? html`<a class="flex flex-row w-100 justify-center bb b--light-silver no-underline" href="/login" target="_blank" rel="noopener noreferer">Log in to listen to full song</a>`
           : ''}
         ${this.renderArtwork()}
         ${this.renderControls()}

--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -330,7 +330,7 @@ class Player extends Nanocomponent {
     return html`
       <div class="player-component flex flex-column h-100">
         ${!isAuthenticated
-          ? html`<span class="flex flex-row w-100 justify-center bb b--light-silver">Log in to listen to full song</span>`
+          ? html`<a class="flex flex-row w-100 justify-center bb b--light-silver no-underline glow" href="/login" target="_blank" rel="noopener noreferer">Log in to listen to full song</a>`
           : ''}
         ${this.renderArtwork()}
         ${this.renderControls()}


### PR DESCRIPTION
These changes turn this whole bar into a clickable button taking the user to the login page. I disabled the automatic underline for the text because it looked a bit odd in this context. We can also make it so just the text is clickable instead of the whole bar, whatever you all prefer.

<img width="1680" alt="Screen Shot 2022-03-04 at 8 19 09 PM" src="https://user-images.githubusercontent.com/60944077/156864107-35d4b3d5-fc68-4d8d-b840-e96e047824ad.png">

This is a followup addition to https://github.com/resonatecoop/stream/pull/131, since users on the forum have been requesting this functionality.