### PR TITLE
Fix height of `Trouble Logging In?` login link to Cookie Settings

### DIFF
--- a/beta/src/components/forms/login.js
+++ b/beta/src/components/forms/login.js
@@ -82,7 +82,7 @@ class Login extends Component {
                   Forgot your password?
                 </a>
               </p>
-              <p align="left" style="margin-top:-5ex;margin-bottom:0;">
+              <p align="left" style="margin-top:-2.715em;margin-bottom:0;">
                 <a href="/settings" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
                   Trouble logging in?
                 </a>

--- a/beta/src/components/forms/login.js
+++ b/beta/src/components/forms/login.js
@@ -77,12 +77,12 @@ class Login extends Component {
           placeholder: 'Password',
           help: html`
             <div>
-              <p align="right" style="margin-top:0">
+              <p class="tr" style="margin-top:0">
                 <a href="https://resonate.is/password-reset/" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
                   Forgot your password?
                 </a>
               </p>
-              <p align="left" style="margin-top:-2.715em;margin-bottom:0;">
+              <p class="tl" style="margin-top:-2.715em;margin-bottom:0;">
                 <a href="/settings" class="lightGrey f7 ma0 pt1 pr2" target="_blank" rel="noopener noreferer">
                   Trouble logging in?
                 </a>


### PR DESCRIPTION
The distance of `Trouble Logging In?` text (introduced in https://github.com/resonatecoop/stream/pull/179) from the password input was slightly too low compared to the `Forgot your password?` link. These changes amend that discrepancy:

<img width="557" alt="Screen Shot 2022-03-04 at 9 44 38 PM" src="https://user-images.githubusercontent.com/60944077/156866518-ac657790-351f-406a-a612-58f4d84fac10.png">
