### PR TITLE
Fix tiny back arrow and track menu icons for iOS mobile

### DIFF
--- a/beta/src/layouts/trackgroup/index.js
+++ b/beta/src/layouts/trackgroup/index.js
@@ -15,7 +15,7 @@ function LayoutTrackGroup (view) {
         <div class="flex flex-column flex-row-l flex-auto w-100">
           <div class="flex flex-column sticky top-0 top-3-l z-999">
             <div class="sticky top-0 z-999 top-3-l z-999 bg-near-black bg-transparent-l">
-              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" onclick=${() => emit('navigate:back')}>
+              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" style="padding:0" onclick=${() => emit('navigate:back')}>
                 <div class="flex items-center justify-center">
                   ${icon('arrow', { size: 'sm' })}
                 </div>

--- a/packages/track-component/index.js
+++ b/packages/track-component/index.js
@@ -156,6 +156,11 @@ class Track extends Component {
       share: true
     }
 
+    let size = this.local.type === 'album' ? 'sm' : 'md' // button size
+    if (/Mobi|iOS/i.test(navigator.userAgent)) {
+      size = this.local.type === 'album' ? 'm' : 'l'
+    }
+
     return menuButton.render({
       items: [], // no custom items yet
       selection: Object.entries(selection).filter(([k, v]) => Boolean(v)).map(([k, v]) => k), // selection to array of keys
@@ -164,7 +169,7 @@ class Track extends Component {
         favorite: this.local.favorite || this.local.fav,
         url: new URL(`/track/${this.local.track.id}`, process.env.APP_HOST || 'https://stream.resonate.coop')
       }),
-      size: this.local.type === 'album' ? 'sm' : 'md', // button size
+      size,
       orientation: 'bottomright'
     })
   }


### PR DESCRIPTION
These changes fix tiny back arrow and track menu icons for iOS mobile.

### Back arrow icon
#### Before
![IMG_9182](https://user-images.githubusercontent.com/60944077/156895163-2b846732-da72-4d63-99cf-f4d77195fbf5.jpg)

#### After
![IMG_9183](https://user-images.githubusercontent.com/60944077/156895164-ace4027f-9e80-4915-baec-a513c53b1063.jpg)


### Track menu ellipse icon
#### Before
![IMG_EFB0FE7B8517-1](https://user-images.githubusercontent.com/60944077/156895165-7a355659-fbe8-4fce-be2d-31c13763e6f0.jpeg)

#### After
![IMG_4AF6195DD162-1](https://user-images.githubusercontent.com/60944077/156895166-f1ce9111-64cf-4e77-8a5c-60c3dc7ea96d.jpeg)

This closes #187.