### PR TITLE
Hide menu login button on login page

### DIFF
--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -220,9 +220,11 @@ class Header extends Component<HeaderProps> {
               `
               : html`<li class="flex flex-auto w-100 justify-center" role="divider"></li>`}
             <li class="${this.state.resolved && !this.state.user.uid ? 'flex' : 'dn'} flex-auto justify-center w-100 grow" role="menuitem">
-              <a class="link pv1 ph3 ttu ba b--mid-gray b--dark-gray--dark db f6 b" href=${AUTH_HREF} >
-                Log In
-              </a>
+            ${this.state.href !== '/login'
+              ? html`<a class="link pv1 ph3 ttu ba b--mid-gray b--dark-gray--dark db f6 b" href=${AUTH_HREF} >
+                  Log In
+                </a>`
+              : ''}
             </li>
             <li class="${this.state.resolved ? 'dn' : 'flex'} flex-auto w-100 justify-center" role="divider"></li>
             <li class="${!this.state.user.uid ? 'dn' : 'flex'} flex-auto justify-center w-100" role="menuitem">


### PR DESCRIPTION
These changes hide the extra menu login button when the user is already on the login page.

### Desktop
#### Before
<img width="1792" alt="Screen Shot 2022-03-06 at 8 52 26 PM" src="https://user-images.githubusercontent.com/60944077/156960335-87c79de6-a216-4020-ab9e-5da148904983.png">

#### After
<img width="1792" alt="Screen Shot 2022-03-06 at 8 52 18 PM" src="https://user-images.githubusercontent.com/60944077/156960341-12fd8125-783f-418a-a4cd-ca30c0b88e22.png">

### Mobile
#### Before
<img width="374" alt="Screen Shot 2022-03-06 at 8 54 32 PM" src="https://user-images.githubusercontent.com/60944077/156960381-caad5127-ec94-4a9f-ac15-a2374460bda5.png">

#### After
<img width="377" alt="Screen Shot 2022-03-06 at 8 53 53 PM" src="https://user-images.githubusercontent.com/60944077/156960392-5760534a-eef5-4638-8006-43f39215120b.png">

This closes #193.