### PR TITLE
Remove Beta App link from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@
       Website
     </a>
     <span> | </span>
-    <a href="https://beta.stream.resonate.coop">
-      Beta app
-    </a>
-    <span> | </span>
     <a href="https://www.twitter.com/resonatecoop/">
       Twitter
     </a>


### PR DESCRIPTION
It seems that (unless I am mistaken) since we are no longer using the [beta](https://beta.stream.resonate.coop) url, we should remove this from the Readme.