### PR TITLE
Fix iOS back arrow size for tags, artists, labels, releases, login pages

### DIFF
--- a/beta/src/layouts/browse/index.js
+++ b/beta/src/layouts/browse/index.js
@@ -16,7 +16,7 @@ module.exports = (view) => {
         <div class="flex flex-column flex-row-l flex-auto w-100">
           <div class="flex flex-column sticky top-0 top-3-l z-999">
             <div class="sticky top-0 z-999 top-3-l z-999 bg-near-black bg-transparent-l">
-              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" onclick=${() => emit('navigate:back')}>
+              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" style="padding:0" onclick=${() => emit('navigate:back')}>
                 <div class="flex items-center justify-center">
                   ${icon('arrow', { size: 'sm' })}
                 </div>

--- a/beta/src/layouts/default/index.js
+++ b/beta/src/layouts/default/index.js
@@ -14,7 +14,7 @@ function LayoutDefault (view) {
       <main class="flex flex-column flex-auto w-100">
         <div class="flex flex-column flex-auto w-100">
           <div class="sticky z-999 bg-near-black top-0 top-3-l">
-            <button class="${bg} br1 bn w2 h2 ma2" onclick=${() => window.history.back()}>
+            <button class="${bg} br1 bn w2 h2 ma2" style="padding:0" onclick=${() => window.history.back()}>
               <div class="flex items-center justify-center">
                 ${icon('arrow', { size: 'sm' })}
               </div>

--- a/beta/src/layouts/library/index.js
+++ b/beta/src/layouts/library/index.js
@@ -34,7 +34,7 @@ function LayoutLibrary (view) {
     return html`
       <main class="flex flex-column flex-auto pb6">
         <div class="sticky top-0 top-3-l fixed-l z-999 bg-near-black bg-transparent-l">
-          <button class="${bg} br1 bn w2 h2 ma2 ma3-l" onclick=${() => emit('navigate:back')}>
+          <button class="${bg} br1 bn w2 h2 ma2 ma3-l" style="padding:0" onclick=${() => emit('navigate:back')}>
             <div class="flex items-center justify-center">
               ${icon('arrow', { size: 'sm' })}
             </div>

--- a/beta/src/layouts/profile/index.js
+++ b/beta/src/layouts/profile/index.js
@@ -53,7 +53,7 @@ function LayoutProfile (view) {
         <div class="flex flex-column flex-auto">
           ${renderProfileHeaderImage(state)}
           <div class="sticky z-999 ${bg} bb b--mid-gray b--mid-gray--light b--near-black--dark top-0 top-3-l">
-            <button class="bg-transparent bn w2 h2 ma2" onclick=${() => emit('navigate:back')}>
+            <button class="bg-transparent bn w2 h2 ma2" style="padding:0" onclick=${() => emit('navigate:back')}>
               <div class="flex items-center justify-center">
                 ${icon('arrow', { size: 'sm' })}
               </div>

--- a/beta/src/layouts/search/index.js
+++ b/beta/src/layouts/search/index.js
@@ -57,7 +57,7 @@ function LayoutSearch (view) {
         <div class="flex flex-column flex-row-l flex-auto w-100">
           <div class="flex flex-column sticky top-0 top-3-l z-999">
             <div class="sticky top-0 z-999 top-3-l z-999 bg-near-black bg-transparent-l">
-              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" onclick=${() => emit('navigate:back')}>
+              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" style="padding:0" onclick=${() => emit('navigate:back')}>
                 <div class="flex items-center justify-center">
                   ${icon('arrow', { size: 'sm' })}
                 </div>


### PR DESCRIPTION
#### Before
![IMG_C44220841135-1](https://user-images.githubusercontent.com/60944077/157776486-08ed0442-2499-4c34-af06-b6ae9372d8cc.jpeg)

#### After
![IMG_C6DD2E397E5F-1](https://user-images.githubusercontent.com/60944077/157775608-fe315504-5136-4ba9-a539-37129cedf46f.jpeg)

This closes https://github.com/resonatecoop/stream/issues/187.