### PR TITLE
Disable zoom in on inputs when pressed for mobile devices

### DIFF
--- a/beta/src/components/header/index.css
+++ b/beta/src/components/header/index.css
@@ -82,7 +82,7 @@ ul[role="menu"].flex-column li.active::after {
   }
 }
 
-/* ajust spacing for fixed|sticky header */
+/* adjust spacing for fixed|sticky header */
 
 #app {
   padding-top: 3rem;
@@ -96,4 +96,11 @@ ul[role="menu"].flex-column li.active::after {
 
 .right-4 {
   right: 4rem;
+}
+
+/* disable zoom in on inputs when pressed for mobile devices */
+@media only screen and (max-width: 760px) {
+  input:focus {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
Currently, for [stream-app](https://github.com/peterklingelhofer/stream-app) users and mobile browser users, pressing in the login input ever-so-slightly zooms in the screen, and the user has to pinch to zoom back out after logging in. Because the zoom in is slight, many users don't realize what happened, and don't know to pinch to zoom out, and simply think something is wrong with our UI.

The text is already `16px`, so no changes to the text visually will occur with this change, it simply makes the mobile browser avoid this automatic zoom in. I'm doing this for `max-width: 760px` to cover mobile and leave existing behavior for tablets and desktops, but would be open for another way of targeting mobile devices that aren't using this breakpoint (if anyone has a better idea I'm all ears).