### PR TITLE
[iOS/mobile only] Trackgroup back arrow, menu icons size fix

### DIFF
--- a/beta/src/layouts/trackgroup/index.js
+++ b/beta/src/layouts/trackgroup/index.js
@@ -15,7 +15,7 @@ function LayoutTrackGroup (view) {
         <div class="flex flex-column flex-row-l flex-auto w-100">
           <div class="flex flex-column sticky top-0 top-3-l z-999">
             <div class="sticky top-0 z-999 top-3-l z-999 bg-near-black bg-transparent-l">
-              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" onclick=${() => emit('navigate:back')}>
+              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" style="padding:0" onclick=${() => emit('navigate:back')}>
                 <div class="flex items-center justify-center">
                   ${icon('arrow', { size: 'sm' })}
                 </div>

--- a/packages/track-component/index.js
+++ b/packages/track-component/index.js
@@ -164,7 +164,7 @@ class Track extends Component {
         favorite: this.local.favorite || this.local.fav,
         url: new URL(`/track/${this.local.track.id}`, process.env.APP_HOST || 'https://stream.resonate.coop')
       }),
-      size: this.local.type === 'album' ? 'sm' : 'md', // button size
+      size: this.local.type === 'album' ? 'md' : 'lg', // button size
       orientation: 'bottomright'
     })
   }


### PR DESCRIPTION
Since https://github.com/resonatecoop/stream/pull/200 was reverted, these changes address the tiny trackgroup back arrow and menu icon sizes for iOS mobile.

#### Before
![IMG_9197](https://user-images.githubusercontent.com/60944077/158910266-ea49a953-5a14-4d79-86e7-c06912b688e9.PNG)
![IMG_9198](https://user-images.githubusercontent.com/60944077/158910271-3b760eda-3343-4d1c-be93-1c0314ca97f1.PNG)


#### After
![IMG_9195](https://user-images.githubusercontent.com/60944077/158910287-42a4f8fe-8abe-4960-a7c6-9f992b1bfc4c.PNG)
![IMG_9196](https://user-images.githubusercontent.com/60944077/158910291-97720295-e24a-4750-bcf1-ca37e347aa41.PNG)

This closes https://github.com/resonatecoop/stream/issues/187.