### PR TITLE
Clicking tag in search toggles search off

### DIFF
--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -433,19 +433,17 @@ class Header extends Component<HeaderProps> {
   }
 
   renderSearch (): HTMLElement {
-    const searchClasses: string = 'search flex-l flex-auto-l w-100-l justify-center-l'
     const search = {
       on: () => this.state.cache(Search, 'search').render({ tags: TAGS }),
       off: () => {
-        const attrs = {
-          onclick: () => {
-            this.local.machine.emit('search:toggle')
-          },
-          class: `js bn dn db-l bg-transparent flex items-center ${searchClasses}`,
-          style: 'height:3rem'
-        }
         return html`
-          <button ${attrs}>
+          <button
+            class="js bn dn db-l bg-transparent flex-l justify-center-l w-100-l flex items-center"
+            onclick = ${() => {
+              this.local.machine.emit('search:toggle')
+            }}
+            style="height:3rem"
+          >
             ${icon('search', { size: 'sm' })}
             <span class="db pl3 near-black near-black--light near-white--dark">Search</span>
           </button>
@@ -454,7 +452,7 @@ class Header extends Component<HeaderProps> {
     }[this.local.machine.state.search]
 
     return html`
-      <div class=${searchClasses}>
+      <div class="search flex-l justify-center-l w-100-l">
         ${search?.()}
       </div>
     `

--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -439,9 +439,7 @@ class Header extends Component<HeaderProps> {
         return html`
           <button
             class="js bn dn db-l bg-transparent flex-l justify-center-l w-100-l flex items-center pointer"
-            onclick = ${() => {
-              this.local.machine.emit('search:toggle')
-            }}
+            onclick = ${() => this.local.machine.emit('search:toggle')}
             style="height:3rem"
           >
             ${icon('search', { size: 'sm' })}

--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -433,14 +433,16 @@ class Header extends Component<HeaderProps> {
   }
 
   renderSearch (): HTMLElement {
+    const searchClasses: string = 'search flex-l flex-auto-l w-100-l justify-center-l'
     const search = {
       on: () => this.state.cache(Search, 'search').render({ tags: TAGS }),
       off: () => {
         const attrs = {
-          onclick: (e) => {
+          onclick: () => {
             this.local.machine.emit('search:toggle')
           },
-          class: 'js bn dn db-l bg-transparent'
+          class: `js bn dn db-l bg-transparent ${searchClasses}`,
+          style: 'height:3rem'
         }
         return html`
           <button ${attrs}>
@@ -454,7 +456,7 @@ class Header extends Component<HeaderProps> {
     }[this.local.machine.state.search]
 
     return html`
-      <div class="search flex-l flex-auto-l w-100-l justify-center-l">
+      <div class=${searchClasses}>
         ${search?.()}
       </div>
     `

--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -441,15 +441,13 @@ class Header extends Component<HeaderProps> {
           onclick: () => {
             this.local.machine.emit('search:toggle')
           },
-          class: `js bn dn db-l bg-transparent ${searchClasses}`,
+          class: `js bn dn db-l bg-transparent flex items-center ${searchClasses}`,
           style: 'height:3rem'
         }
         return html`
           <button ${attrs}>
-            <div class="flex items-center">
-              ${icon('search', { size: 'sm' })}
-              <span class="db pl3 near-black near-black--light near-white--dark">Search</span>
-            </div>
+            ${icon('search', { size: 'sm' })}
+            <span class="db pl3 near-black near-black--light near-white--dark">Search</span>
           </button>
         `
       }

--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -438,7 +438,7 @@ class Header extends Component<HeaderProps> {
       off: () => {
         return html`
           <button
-            class="js bn dn db-l bg-transparent flex-l justify-center-l w-100-l flex items-center"
+            class="js bn dn db-l bg-transparent flex-l justify-center-l w-100-l flex items-center pointer"
             onclick = ${() => {
               this.local.machine.emit('search:toggle')
             }}

--- a/packages/search-component/index.js
+++ b/packages/search-component/index.js
@@ -144,10 +144,17 @@ class Search extends Component {
                     const url = new URL('/tag', this.local.applicationHost || 'http://localhost')
                     url.search = new URLSearchParams({ term: tag.toLowerCase() })
                     const href = this.local.applicationHost ? url.href : url.pathname + url.search
+                    const clickTagHandler = () => {
+                      document.getElementById(`search-tag-href-${tag}`).click()
+                      this.state.components.header.machine.emit('search:toggle')
+                    }
 
                     return html`
                       <li>
-                        <a class="link db ph1 black mr1 mv1 f5 br-pill bg-light-gray" href=${href}>#${tag}</a>
+                        <a href=${href} id=search-tag-href-${tag} style="display:none"></a>
+                        <a class="link db ph1 black mr1 mv1 f5 br-pill bg-light-gray pointer" id=search-tag-${tag} onclick=${clickTagHandler}>
+                          #${tag}
+                        </a>
                       </li>
                     `
                   })}
@@ -158,13 +165,20 @@ class Search extends Component {
               <dt class="f6 b ${this.local.artists.length ? 'db' : 'dn'}">Play history</dt>
               <dd class="ma0">
                 <ul class="list ma0 pa0 flex flex-column">
-                  ${this.local.artists.map(({ meta_value: name }) => html`
-                    <li class="mb2">
-                      <a class="db lh-copy f5 link" href="/search?q=${name}">
-                        ${name}
-                      </a>
-                    </li>
-                  `
+                  ${this.local.artists.map(({ meta_value: name }) => {
+                    const clickSearchHistoryHandler = () => {
+                      document.getElementById(`search-history-href-${name}`).click()
+                      this.state.components.header.machine.emit('search:toggle')
+                    }
+
+                    return html`
+                      <li class="mb2">
+                        <a href="/search?q=${name}" id=search-history-href-${name} style="display:none"></a>
+                        <a class="db lh-copy f5 link underline-hover pointer" onclick=${clickSearchHistoryHandler}>
+                          ${name}
+                        </a>
+                      </li>`
+                  }
                   )}
                 </ul>
               </dd>

--- a/packages/search-component/index.js
+++ b/packages/search-component/index.js
@@ -89,6 +89,11 @@ class Search extends Component {
       `
     }
 
+    const handleTagArtistClick = (href) => {
+      this.state.components.header.machine.emit('search:toggle')
+      this.emit(this.state.events.PUSHSTATE, href)
+    }
+
     const searchInput = () => {
       const attrs = {
         class: 'bg-near-white bg-near-white--light black black--light bg-near-black--dark light-gray--dark pv3 pl1 pr0 w-100 bn',
@@ -144,15 +149,10 @@ class Search extends Component {
                     const url = new URL('/tag', this.local.applicationHost || 'http://localhost')
                     url.search = new URLSearchParams({ term: tag.toLowerCase() })
                     const href = this.local.applicationHost ? url.href : url.pathname + url.search
-                    const clickTagHandler = () => {
-                      document.getElementById(`search-tag-href-${tag}`).click()
-                      this.state.components.header.machine.emit('search:toggle')
-                    }
 
                     return html`
                       <li>
-                        <a href=${href} id=search-tag-href-${tag} style="display:none"></a>
-                        <a class="link db ph1 black mr1 mv1 f5 br-pill bg-light-gray pointer" id=search-tag-${tag} onclick=${clickTagHandler}>
+                        <a class="link db ph1 black mr1 mv1 f5 br-pill bg-light-gray pointer" id=search-tag-${tag} onclick=${() => handleTagArtistClick(href)}>
                           #${tag}
                         </a>
                       </li>
@@ -166,15 +166,9 @@ class Search extends Component {
               <dd class="ma0">
                 <ul class="list ma0 pa0 flex flex-column">
                   ${this.local.artists.map(({ meta_value: name }) => {
-                    const clickSearchHistoryHandler = () => {
-                      document.getElementById(`search-history-href-${name}`).click()
-                      this.state.components.header.machine.emit('search:toggle')
-                    }
-
                     return html`
                       <li class="mb2">
-                        <a href="/search?q=${name}" id=search-history-href-${name} style="display:none"></a>
-                        <a class="db lh-copy f5 link underline-hover pointer" onclick=${clickSearchHistoryHandler}>
+                        <a class="db lh-copy f5 link underline-hover pointer" onclick=${() => handleTagArtistClick(`/search?q=${name}`)}>
                           ${name}
                         </a>
                       </li>`


### PR DESCRIPTION
These changes make it so on the Search bar and clicking a tag send you to that tag and de-focus the search bar, closing the search menu. Also, clicking an artist in your search history does the same. Hovering over an artist in search history underlines it.

This closes #210.