### PR TITLE
Type tracks client

### DIFF
--- a/@types/process.d.ts
+++ b/@types/process.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+  export interface ProcessEnv {
+    APP_HOST: string
+  }
+}

--- a/packages/api-service/.eslintrc.js
+++ b/packages/api-service/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: '../../.eslintrc.js',
+  parserOptions: {
+    project: './tsconfig.json'
+  }
+}

--- a/packages/api-service/index.ts
+++ b/packages/api-service/index.ts
@@ -10,8 +10,8 @@ interface APIServiceClientOptions {
 }
 
 interface APIService {
-  getAPIServiceClient: (name: string, prefix?: string, swaggerOpts?: object) => Promise<Function>
-  getAPIServiceClientWithAuth: (token?: string, prefix?: string) => (name: string) => Promise<Function>
+  getAPIServiceClient: (name: string, prefix?: string, swaggerOpts?: object) => Promise<any>
+  getAPIServiceClientWithAuth: (token?: string, prefix?: string) => (name: string) => Promise<any>
 }
 
 /**

--- a/packages/api-service/index.ts
+++ b/packages/api-service/index.ts
@@ -9,10 +9,15 @@ interface APIServiceClientOptions {
   fullClient?: boolean
 }
 
+interface APIService {
+  getAPIServiceClient: (name: string, prefix?: string, swaggerOpts?: object) => Promise<Function>
+  getAPIServiceClientWithAuth: (token?: string, prefix?: string) => (name: string) => Promise<Function>
+}
+
 /**
  * @description API Service client
  */
-const APIServiceClient = (options: APIServiceClientOptions): Function => {
+const APIServiceClient = (options: APIServiceClientOptions): (name: string, prefix?: string, swaggerOpts?: object) => Promise<Function> => {
   const {
     apiHost = 'https://stream.resonate.coop',
     base = '/api/v2',
@@ -67,7 +72,7 @@ const APIServiceClient = (options: APIServiceClientOptions): Function => {
   }
 }
 
-const APIServiceClientWithAuth = (options: APIServiceClientOptions): Function => {
+const APIServiceClientWithAuth = (options: APIServiceClientOptions): (token?: string, prefix?: string) => (name: string) => Promise<Function> => {
   /**
    * @description Get swagger api definition with auth
    * @param {String} token Resonate User Token
@@ -83,13 +88,13 @@ const APIServiceClientWithAuth = (options: APIServiceClientOptions): Function =>
       }
     }
 
-    return (name: string) => {
-      return APIServiceClient(options)(name, prefix, swaggerOpts)
+    return async (name: string) => {
+      return await APIServiceClient(options)(name, prefix, swaggerOpts)
     }
   }
 }
 
-const getService = (options): { getAPIServiceClient: Function, getAPIServiceClientWithAuth: Function } => {
+const getService = (options: APIServiceClientOptions): APIService => {
   return {
     getAPIServiceClient: APIServiceClient(options),
     getAPIServiceClientWithAuth: APIServiceClientWithAuth(options)

--- a/packages/api-service/package.json
+++ b/packages/api-service/package.json
@@ -2,7 +2,7 @@
   "name": "@resonate/api-service",
   "version": "1.1.0",
   "description": "API Service Swagger Client Loader",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "eslint . && dependency-check ."
   },

--- a/packages/api-service/package.json
+++ b/packages/api-service/package.json
@@ -4,7 +4,8 @@
   "description": "API Service Swagger Client Loader",
   "main": "dist/index.js",
   "scripts": {
-    "test": "eslint . && dependency-check ."
+    "test": "eslint . && dependency-check ./index.ts",
+    "build:ts": "tsc -b --force"
   },
   "keywords": [
     "api",

--- a/packages/api-service/tracks.ts
+++ b/packages/api-service/tracks.ts
@@ -1,0 +1,25 @@
+import APIService from './index'
+
+export interface Track {
+  id: number
+  album: object
+  artist: object
+  cover: string
+  title: string
+  url: string
+}
+
+export interface TrackAPIResponse {
+  body: {
+    data: Track
+  }
+}
+
+interface TracksClient {
+  getTrack: (params: { id: number }) => TrackAPIResponse
+}
+
+export async function getTracksClient (apiHost: string): Promise<TracksClient> {
+  const { getAPIServiceClient } = APIService({ apiHost: apiHost })
+  return getAPIServiceClient('tracks')
+}

--- a/packages/api-service/tracks.ts
+++ b/packages/api-service/tracks.ts
@@ -1,20 +1,36 @@
-import { APIResponse, ClientGetter } from './types'
+import { APIResponse, ClientGetter, Cover, CoverMetadata, PagedRequest, PagedResponse } from './types'
 
 export interface Track {
   id: number
-  album: object
-  artist: object
-  cover: string
+  creator_id: number
   title: string
+  duration: number
+  album: string | null
+  year?: number | null
+  artist: string
+  cover: string
+  cover_metadata: CoverMetadata
+  status: string
   url: string
+  images: {
+    small: Cover
+    medium: Cover
+    large: Cover
+  }
 }
 
 export interface TrackResponse {
   data: Track
 }
 
+export interface TracksResponse extends PagedResponse<Track> {}
+
+export interface LatestTracksResponse extends Omit<PagedResponse<Track>, 'status'> {}
+
 interface TracksClient {
   getTrack: (params: { id: number }) => Promise<APIResponse<TrackResponse>>
+  getTracks: (params: PagedRequest & { order?: string }) => Promise<APIResponse<TracksResponse>>
+  getLatestTracks: (params: PagedRequest & { order?: string }) => Promise<APIResponse<LatestTracksResponse>>
 }
 
 export async function getTracksClient (clientGetter: ClientGetter): Promise<TracksClient> {

--- a/packages/api-service/tracks.ts
+++ b/packages/api-service/tracks.ts
@@ -14,7 +14,7 @@ export interface TrackResponse {
 }
 
 interface TracksClient {
-  getTrack: (params: { id: number }) => APIResponse<TrackResponse>
+  getTrack: (params: { id: number }) => Promise<APIResponse<TrackResponse>>
 }
 
 export async function getTracksClient (clientGetter: ClientGetter): Promise<TracksClient> {

--- a/packages/api-service/tracks.ts
+++ b/packages/api-service/tracks.ts
@@ -1,4 +1,4 @@
-import APIService from './index'
+import { APIResponse, ClientGetter } from './types'
 
 export interface Track {
   id: number
@@ -9,17 +9,14 @@ export interface Track {
   url: string
 }
 
-export interface TrackAPIResponse {
-  body: {
-    data: Track
-  }
+export interface TrackResponse {
+  data: Track
 }
 
 interface TracksClient {
-  getTrack: (params: { id: number }) => TrackAPIResponse
+  getTrack: (params: { id: number }) => APIResponse<TrackResponse>
 }
 
-export async function getTracksClient (apiHost: string): Promise<TracksClient> {
-  const { getAPIServiceClient } = APIService({ apiHost: apiHost })
-  return getAPIServiceClient('tracks')
+export async function getTracksClient (clientGetter: ClientGetter): Promise<TracksClient> {
+  return clientGetter('tracks')
 }

--- a/packages/api-service/tracks.ts
+++ b/packages/api-service/tracks.ts
@@ -6,26 +6,39 @@ export interface Track {
   title: string
   duration: number
   album: string | null
-  year?: number | null
   artist: string
   cover: string
   cover_metadata: CoverMetadata
-  status: string
+  images: {
+    small: Cover
+    medium: Cover
+  }
+  status: 'Paid'
   url: string
+}
+
+export interface SingleTrack extends Track {
   images: {
     small: Cover
     medium: Cover
     large: Cover
   }
+  year: number | null
 }
 
 export interface TrackResponse {
-  data: Track
+  data: SingleTrack
 }
 
-export interface TracksResponse extends PagedResponse<Track> {}
+export interface MultiTrack extends Track {
+  year: number | null
+}
 
-export interface LatestTracksResponse extends Omit<PagedResponse<Track>, 'status'> {}
+export interface MultiLatestTrack extends Track {}
+
+export interface TracksResponse extends PagedResponse<MultiTrack> {}
+
+export interface LatestTracksResponse extends Omit<PagedResponse<MultiLatestTrack>, 'status'> {}
 
 interface TracksClient {
   getTrack: (params: { id: number }) => Promise<APIResponse<TrackResponse>>

--- a/packages/api-service/tsconfig.json
+++ b/packages/api-service/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+  },
+  "include": ["../@types", "./**/*"]
+}

--- a/packages/api-service/types.ts
+++ b/packages/api-service/types.ts
@@ -4,12 +4,24 @@ export interface APIResponse<T> {
   body: T
 }
 
+export interface PagedRequest {
+  limit?: number
+  page?: number
+}
+
+export interface PagedResponse<T> {
+  data: T[]
+  count: number
+  numberOfPages: number
+  status: string
+}
+
 export interface CoverMetadata {
-  id: string
+  id: string | null
 }
 
 export interface Cover {
   height: number
   width: number
-  url: string
+  url?: string
 }

--- a/packages/api-service/types.ts
+++ b/packages/api-service/types.ts
@@ -1,0 +1,15 @@
+export type ClientGetter = (name: string) => any
+
+export interface APIResponse<T> {
+  body: T
+}
+
+export interface CoverMetadata {
+  id: string
+}
+
+export interface Cover {
+  height: number
+  width: number
+  url: string
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   "include": ["@types"],
   "references": [
     { "path": "./beta" },
+    { "path": "./packages/api-service" },
     { "path": "./packages/button" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,9 @@
   },
   "include": ["@types"],
   "references": [
-    { "path": "./beta" },
+    // The packages have to be arranged in an order where deps of packages come before the packages in question
     { "path": "./packages/api-service" },
-    { "path": "./packages/button" }
+    { "path": "./packages/button" },
+    { "path": "./beta" }
   ]
 }


### PR DESCRIPTION
This PR sets up typed API clients (will exist alongside the non-typed ones until everything has been moved) as well as types the tracks client. The types are just derived from calling the different endpoints and looking at various samples of responses. Without more insight into the actual API spec this is just best-effort, but it's certainly better than nothing and can be improved in time.

I did discover some interesting discrepancies so far. For example, the `year` of a track is missing if you use the `/latest` endpoint. However, this has been accounted for in the types.