### PR TITLE
Fix trackgroup back arrow icon size for iOS

### DIFF
--- a/beta/src/layouts/trackgroup/index.js
+++ b/beta/src/layouts/trackgroup/index.js
@@ -15,7 +15,7 @@ function LayoutTrackGroup (view) {
         <div class="flex flex-column flex-row-l flex-auto w-100">
           <div class="flex flex-column sticky top-0 top-3-l z-999">
             <div class="sticky top-0 z-999 top-3-l z-999 bg-near-black bg-transparent-l">
-              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" onclick=${() => emit('navigate:back')}>
+              <button class="${bg} br1 bn w2 h2 ma2 ma3-l" style="padding:0" onclick=${() => emit('navigate:back')}>
                 <div class="flex items-center justify-center">
                   ${icon('arrow', { size: 'sm' })}
                 </div>


### PR DESCRIPTION
Since https://github.com/resonatecoop/stream/pull/215 had to be reverted, these changes implement the back arrow icon size fix for iOS. Will try to address the menu icon size bug on iOS in a separate pull request.

#### Before
![IMG_9197](https://user-images.githubusercontent.com/60944077/158910266-ea49a953-5a14-4d79-86e7-c06912b688e9.PNG)

#### After
![IMG_9196](https://user-images.githubusercontent.com/60944077/158910291-97720295-e24a-4750-bcf1-ca37e347aa41.PNG)

This closes https://github.com/resonatecoop/stream/issues/187.