### PR TITLE
Hide notification settings on iOS

### DIFF
--- a/beta/src/views/settings/index.js
+++ b/beta/src/views/settings/index.js
@@ -21,35 +21,46 @@ function renderSettings (state, emit) {
   })
 
   const cookieConsentGranted = state.cookieConsentStatus === 'allow'
+  const iOS = (navigator !== undefined && 'userAgent' in navigator) &&
+    (navigator.userAgent.match(/iOS/) ||
+    (navigator.userAgent.match(/Mac/) && document !== undefined && 'ontouchend' in document))
+
+  const notificationsSection = html`
+    <div class="bg-light-gray bg-light-gray--light bg-transparent--dark ba b--gray b--gray--light b--near-black--dark mb3 pa3">
+      <fieldset class="pa0 ma0 bn">
+        <legend class="f3 lh-title ma0 pa0">Notifications</legend>
+        <div class="mt2 mb4">
+          <label for="notify" class="f5 lh-copy db mb2 required">${!state.notification.permission ? 'Native notifications are disabled' : 'Native notifications are enabled. To change this configuration, update your site settings for ' + process.env.APP_DOMAIN}.</label>
+          ${enableNotificationButton}
+        </div>
+      </fieldset>
+    </div>
+  `
+
+  const cookieConsentSection = html`
+    <div class="bg-light-gray bg-light-gray--light bg-transparent--dark ba b--gray b--gray--light b--near-black--dark mb3 pa3">
+      <fieldset class="pa0 ma0 bn">
+        <legend class="f3 lh-title ma0">Cookie consent</legend>
+        <div class="mt2 mb4">
+          <label for="cache" class="f5 lh-copy db mb2 required">Cookies are ${cookieConsentGranted ? 'allowed' : 'disabled'}</label>
+          ${cookiesOptions}
+          ${!cookieConsentGranted
+            ? html`
+            <br>
+            <br>
+            <p class="lh-copy f5 b">Disable functional cookies only if you expect Resonate to not persist your session.</p>
+            `
+            : ''
+            }
+        </div>
+      </fieldset>
+    </div>
+  `
 
   return html`
     <section id="app-settings" class="flex flex-column ph4 mt3">
-      <div class="bg-light-gray bg-light-gray--light bg-transparent--dark ba b--gray b--gray--light b--near-black--dark mb3 pa3">
-        <fieldset class="pa0 ma0 bn">
-          <legend class="f3 lh-title ma0 pa0">Notifications</legend>
-          <div class="mt2 mb4">
-            <label for="notify" class="f5 lh-copy db mb2 required">${!state.notification.permission ? 'Native notifications are disabled' : 'Native notifications are enabled. To change this configuration, update your site settings for ' + process.env.APP_DOMAIN}.</label>
-            ${enableNotificationButton}
-          </div>
-        </fieldset>
-      </div>
-      <div class="bg-light-gray bg-light-gray--light bg-transparent--dark ba b--gray b--gray--light b--near-black--dark mb3 pa3">
-        <fieldset class="pa0 ma0 bn">
-          <legend class="f3 lh-title ma0">Cookie consent</legend>
-          <div class="mt2 mb4">
-            <label for="cache" class="f5 lh-copy db mb2 required">Cookies are ${cookieConsentGranted ? 'allowed' : 'disabled'}</label>
-            ${cookiesOptions}
-            ${!cookieConsentGranted
-              ? html`
-              <br>
-              <br>
-              <p class="lh-copy f5 b">Disable functional cookies only if you expect Resonate to not persist your session.</p>
-              `
-              : ''
-              }
-          </div>
-        </fieldset>
-      </div>
+      ${!iOS ? notificationsSection : ''}
+      ${cookieConsentSection}
     </section>
   `
 }


### PR DESCRIPTION
These changes should hide the notification settings section for iOS, as they are [unsupported](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).

<img width="390" alt="Screen Shot 2022-04-20 at 5 56 52 PM" src="https://user-images.githubusercontent.com/60944077/164339434-5e18e279-29d6-41df-a30f-ae7af5cf5695.png">

This closes #227.