### PR TITLE
fix: update blog and handbook links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing! Please see the [Developer Guide](https://community.resonate.is/t/dev-volunteers-needed-to-build-the-resonate-ecosystem/2262) in our [Resonate Handbook](https://community.resonate.is/docs) for a clear overview of all things development related.
+Thanks for your interest in contributing! Please see the [Developer Guide](https://community.resonate.is/t/dev-volunteers-needed-to-build-the-resonate-ecosystem/2262) in our [Resonate Handbook](https://community.resonate.coop/docs) for a clear overview of all things development related.
 
 There are many ways to contribute:
 - Refactoring code

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://resonate.is">
+    <a href="https://resonate.coop">
       Website
     </a>
     <span> | </span>
@@ -19,7 +19,7 @@
       Contributing
     </a>
     <span> | </span>
-    <a href="https://community.resonate.is/t/dev-volunteers-needed-to-build-the-resonate-ecosystem/2262">
+    <a href="https://community.resonate.coop/t/dev-volunteers-needed-to-build-the-resonate-ecosystem/2262">
       Developer Guide
     </a>
     <span> | </span>
@@ -41,11 +41,11 @@
 
 Resonate is an open-source music streaming service run by a cooperative of artists and software developers.
 
-If you want to know what we're building or want to get more involved, head over to the Platform category on our [forum](https://community.resonate.is/c/platform/l/latest?board=default) or read the [Developer Guide](https://community.resonate.is/t/dev-volunteers-needed-to-build-the-resonate-ecosystem/2262) in our [Resonate Handbook](https://community.resonate.is/docs).
+If you want to know what we're building or want to get more involved, head over to the Platform category on our [forum](https://community.resonate.is/c/platform/l/latest?board=default) or read the [Developer Guide](https://community.resonate.coop/t/dev-volunteers-needed-to-build-the-resonate-ecosystem/2262) in our [Resonate Handbook](https://community.resonate.coop/docs).
 
 If you're looking for a good first task, feel encouraged to take on an un-assigned ['help wanted' issues](https://github.com/resonatecoop/stream/issues).
 
-Are you building something using the Resonate [API](#api) and would like to request a change? Resonate welcomes #proposals in the [Co-Operation section of the forum](https://community.resonate.is/c/66).
+Are you building something using the Resonate [API](#api) and would like to request a change? Resonate welcomes #proposals in the [Co-Operation section of the forum](https://community.resonate.coop/c/66).
 
 ## Table of Contents
 - [Development](#development)
@@ -63,7 +63,7 @@ Are you building something using the Resonate [API](#api) and would like to requ
 Quick-n-dirty instructions to get the player up and running on your computer using http and pointing to the existing production API (see [API](#api) to learn more about the API).
 Assumes the latest version of [node.js](https://nodejs.org/).
 
-_Stuck? Make an issue on Github! Curious about the roadmap? Ask in the [forum](https://community.resonate.is/t/development-team/1724)_.
+_Stuck? Make an issue on Github! Curious about the roadmap? Ask in the [forum](https://community.resonate.coop/t/development-team/1724)_.
 
 Clone the repo and `cd` into it:
 
@@ -162,7 +162,7 @@ You should now see the player running on https://beta.resonate.localhost or
 
 ### API
 
-If you want to build on the API for personal use, consider checking the [backlog in our community forum](https://community.resonate.is/c/platform/52).
+If you want to build on the API for personal use, consider checking the [backlog in our community forum](https://community.resonate.coop/c/platform/52).
 The Tracks API repo is currently private, but you may ask for access in the forum.
 
 The Swagger API documentation is currently in flux and split across the [Resonate Search API](https://api.resonate.coop/v2/docs) (see the top right corner for the different services) and [Resonate Service Documentation: User](https://api.resonate.ninja/#/).

--- a/beta/src/components/footer/index.js
+++ b/beta/src/components/footer/index.js
@@ -32,12 +32,12 @@ class Footer extends Component {
                 ${link({
                   prefix: 'link mid-gray pa0 lh-copy',
                   text: 'Blog',
-                  href: 'https://resonate.coop/blog',
+                  href: 'https://community.resonate.coop/c/blog/104',
                   target: '_blank'
                 })}
               </dd>
               <dd class="ma0 pb2">
-                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Handbook', href: 'https://community.resonate.is/docs', target: '_blank' })}
+                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Handbook', href: 'https://community.resonate.coop/docs', target: '_blank' })}
               </dd>
             </dl>
 
@@ -47,7 +47,7 @@ class Footer extends Component {
             <dl>
               <dt class="ttu mb2">Community</dt>
               <dd class="ma0 pb2">
-                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Join', href: 'https://resonate.is/join', target: '_blank' })}
+                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Join', href: 'https://resonate.coop/join', target: '_blank' })}
               </dd>
               <dd class="ma0 pb2">
                 ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Volunteering', href: 'https://resonate.coop/volunteering', target: '_blank' })}
@@ -56,13 +56,13 @@ class Footer extends Component {
                 ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Team', href: 'https://resonate.coop/team', target: '_blank' })}
               </dd>
               <dd class="ma0 pb2">
-                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Forum', href: 'https://community.resonate.is', target: '_blank' })}
+                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Forum', href: 'https://community.resonate.coop', target: '_blank' })}
               </dd>
             </dl>
 
             <div class="flex flex-column h-100 justify-end">
               <p class="dark-gray f5">
-                ${link({ prefix: 'link ttu', href: 'https://resonate.is/terms-conditions', text: 'Terms + Conditions' })}
+                ${link({ prefix: 'link ttu', href: 'https://resonate.coop/terms-conditions', text: 'Terms + Conditions' })}
               </p>
             </div>
           </div>

--- a/beta/src/views/faq/index.js
+++ b/beta/src/views/faq/index.js
@@ -7,7 +7,7 @@ const faq = [
     items: [
       {
         question: 'Why can\'t I listen to more than 45 seconds of a track?',
-        answer: 'When not logged in, you are using Resonate in preview mode. <a href="https://resonate.is/join/" target="_blank">Create an account</a> and log in to listen to full tracks. If you are logged in and still can’t hear full tracks, you are likely out of listening credits. You can purchase more via your user menu.'
+        answer: 'When not logged in, you are using Resonate in preview mode. <a href="https://resonate.coop/join/" target="_blank">Create an account</a> and log in to listen to full tracks. If you are logged in and still can’t hear full tracks, you are likely out of listening credits. You can purchase more via your user menu.'
       },
       {
         question: 'Search by tag',
@@ -116,7 +116,7 @@ const faq = [
       },
       {
         question: 'How do I get an Artist Account?',
-        answer: 'Sign up <a href="https://resonate.is/join/" target="_blank">here</a>.'
+        answer: 'Sign up <a href="https://resonate.coop/join/" target="_blank">here</a>.'
       },
       {
         question: 'What can I do with an Artist Account?',
@@ -124,7 +124,7 @@ const faq = [
       },
       {
         question: 'How do I upload music to Resonate?',
-        answer: 'Once it is ready, our new Artist Dashboard will put the upload process under your control. For now, volunteers at Resonate will upload your music for you. To submit music, log in to your Artist Account at <a href="https://resonate.is" target="_blank">https://resonate.is</a>, complete your Artist Profile, and then follow the guidance on the Submitting Music page.'
+        answer: 'Once it is ready, our new Artist Dashboard will put the upload process under your control. For now, volunteers at Resonate will upload your music for you. To submit music, log in to your Artist Account at <a href="https://resonate.coop" target="_blank">https://resonate.coop</a>, complete your Artist Profile, and then follow the guidance on the Submitting Music page.'
       },
       {
         question: 'How do I get a Label Account?',
@@ -192,7 +192,7 @@ function renderFaq (state, emit) {
       <section id="faq" class="flex flex-column w-100 ph3 pb6">
         <h1 class="f3 lh-title fw4">Frequently asked questions</h1>
 
-        <p class="measure">If you’d like help and your question isn’t answered here, request an invite to our <a href="https://community.resonate.is">Community Forum</a> where you can meet others, ask questions, and read our co-op Handbook. Resonate is a labor of love by a small community. Your ideas, music, listening and <a href="https://opencollective.com/resonate">donations</a> can help make this everything it can be.</p>
+        <p class="measure">If you’d like help and your question isn’t answered here, request an invite to our <a href="https://community.resonate.coop">Community Forum</a> where you can meet others, ask questions, and read our co-op Handbook. Resonate is a labor of love by a small community. Your ideas, music, listening and <a href="https://opencollective.com/resonate">donations</a> can help make this everything it can be.</p>
 
         ${faq.map((item) => {
           return html`


### PR DESCRIPTION
Addresses https://github.com/resonatecoop/website/issues/47 and https://github.com/resonatecoop/website/issues/48 in this repo.