### PR TITLE
fix: co-op menu links

### DIFF
--- a/beta/src/components/footer/index.js
+++ b/beta/src/components/footer/index.js
@@ -26,7 +26,7 @@ class Footer extends Component {
                 ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'Pricing', href: 'https://resonate.coop/pricing', target: '_blank' })}
               </dd>
               <dd class="ma0 pb2">
-                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'The Co-op', href: 'https://resonate.coop/the-coop', target: '_blank' })}
+                ${link({ prefix: 'link mid-gray pa0 lh-copy', text: 'The Co-op', href: 'https://resonate.coop/coop', target: '_blank' })}
               </dd>
               <dd class="ma0 pb2">
                 ${link({

--- a/beta/src/components/header/index.ts
+++ b/beta/src/components/header/index.ts
@@ -294,7 +294,7 @@ class Header extends Component<HeaderProps> {
                   <a class="link db w-100 ph3 pv2 bg-animate hover-bg-light-gray hover-bg-light-gray--light hover-bg-dark-gray--dark" href="https://resonate.coop/pricing" target="_blank">Pricing</a>
                 </li>
                 <li>
-                  <a class="link db w-100 ph3 pv2 bg-animate hover-bg-light-gray hover-bg-light-gray--light hover-bg-dark-gray--dark" href="https://resonate.coop/the-coop" target="_blank">The Co-op</a>
+                  <a class="link db w-100 ph3 pv2 bg-animate hover-bg-light-gray hover-bg-light-gray--light hover-bg-dark-gray--dark" href="https://resonate.coop/coop" target="_blank">The Co-op</a>
                 </li>
                 <li>
                   <a class="link db w-100 ph3 pv2 bg-animate hover-bg-light-gray hover-bg-light-gray--light hover-bg-dark-gray--dark" href="/faq">FAQ</a>


### PR DESCRIPTION
This was causing 404s. Link moved from `/the-coop` => `/coop` during the transition.