### PR TITLE
fix: link log in to listen to full song

### DIFF
--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -319,7 +319,7 @@ class Player extends Nanocomponent {
     const classesInfoBar = 'flex flex-row w-100 justify-center bb b--light-silver no-underline'
     let infoBar = ''
     if (!isAuthenticated) {
-      infoBar = html`<a class=${classesInfoBar} href="/login" target="_blank" rel="noopener noreferer">Log in to listen to full song</a>`
+      infoBar = html`<a class=${classesInfoBar} href="/api/v3/user/connect/resonate" target="_blank" rel="noopener noreferer">Log in to listen to full song</a>`
     } else if (Number(this.state.user.credits) < 0.002 && this.local.count < 9) {
       infoBar = html`<a class=${classesInfoBar}>You don’t have enough credits to play the current track in full’</a>`
     }


### PR DESCRIPTION
![Screen Shot 2022-08-14 at 7 57 40 PM](https://user-images.githubusercontent.com/60944077/184561903-3408f4d5-0b3b-459f-9a2e-56425b3ec59f.png)

Fixing this link to use the route for APIv3.

Maybe we should consider just routing `/login` to `/api/v3/user/connect/resonate`?