### PR TITLE
fixed Parsing error: Cannot read file .../tsconfig.json .eslint error…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
     node: true
   },
   parserOptions: {
-    project: './tsconfig.json'
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname
   },
   overrides: [{
     files: ['*.ts', '*.tsx'],


### PR DESCRIPTION
Using VSCode 1.71

After cloning and npm install, got problems when opening files in @types folder.
Short version: [Parsing error: Cannot read file '.../tsconfig.json'.eslint]
Created red squigglies in all affected files.

Not a critical problem, but definitely a distraction. Something that shouldn't be a problem.

Fixed by adding 'tsconfigRootDir: __dirname,' to 'parserOptions' block of .eslintrc.js file

More reference here ->
(https://stackoverflow.com/questions/64933543/parsing-error-cannot-read-file-tsconfig-json-eslint)