### PR TITLE
Pressing a track's title plays/pauses track, clicking artist goes to artist page

### DIFF
--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -345,7 +345,7 @@ class Player extends Nanocomponent {
       const { title, artist, creator_id: id } = props
       const attrs = {
         href: `/artist/${id}`,
-        class: 'link no-underline underline-hover pointer color-inherit track-artist truncate f5 dark-gray mid-gray--dark dark-gray--light'
+        class: 'link no-underline underline-hover color-inherit track-artist truncate f5 dark-gray mid-gray--dark dark-gray--light'
       }
 
       if (this.local.inIframe) {
@@ -490,7 +490,7 @@ class Player extends Nanocomponent {
               ${renderSeeker({ force: true })}
             </div>
             <div class="flex w-100 flex-auto">
-              <div class="flex flex-auto w-100 pointer">
+              <div class="flex flex-auto w-100">
                 ${renderFullScreenButton()}
                 ${renderInfos(this.local.track)}
                 ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}

--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -345,7 +345,7 @@ class Player extends Nanocomponent {
       const { title, artist, creator_id: id } = props
       const attrs = {
         href: `/artist/${id}`,
-        class: 'link no-underline color-inherit track-artist truncate f5 dark-gray mid-gray--dark dark-gray--light'
+        class: 'link no-underline underline-hover pointer color-inherit track-artist truncate f5 dark-gray mid-gray--dark dark-gray--light'
       }
 
       if (this.local.inIframe) {
@@ -355,14 +355,12 @@ class Player extends Nanocomponent {
 
       return html`
         <div class="infos flex flex-auto w-auto w-33-l justify-center flex-column">
-          <div>
-            <span
-              class="track-title truncate f5 pointer no-underline underline-hover"
-              onclick=${() => { this.local.playback.emit(this.playing() ? 'pause' : 'play') }}
-              >
-              ${title}
-            </span>
-          </div>
+          <span
+            class="track-title truncate f5 pointer no-underline underline-hover"
+            onclick=${() => { this.local.playback.emit(this.playing() ? 'pause' : 'play') }}
+            >
+            ${title}
+          </span>
           <a ${attrs}>
             ${artist}
           </a>

--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -355,9 +355,11 @@ class Player extends Nanocomponent {
 
       return html`
         <div class="infos flex flex-auto w-auto w-33-l justify-center flex-column">
-          <span class="track-title truncate f5">
-            ${title}
-          </span>
+          <div onclick=${() => { this.local.playback.emit(this.playing() ? 'pause' : 'play') }}>
+            <span class="track-title truncate f5 pointer no-underline underline-hover">
+              ${title}
+            </span>
+          </div>
           <a ${attrs}>
             ${artist}
           </a>
@@ -471,7 +473,7 @@ class Player extends Nanocomponent {
         return html`
           <div class="controls flex flex-column flex-auto flex-column h-100 bt bw b--mid-gray b--near-black--dark">
             <div class="flex flex-auto">
-              <div class="flex w-100 flex-auto ml2">
+              <div class="flex w-100 flex-auto ml2 pointer">
                 ${renderVolumeControl({ force: true })}
               </div>
               <div class="flex w-100 justify-center flex-auto">
@@ -483,11 +485,11 @@ class Player extends Nanocomponent {
                 ${!this.local.hideCount ? renderPlayCount() : ''}
               </div>
             </div>
-            <div class="bg-near-white bg-near-white--light bg-near-black--dark flex flex-auto w-100 h2">
+            <div class="bg-near-white bg-near-white--light bg-near-black--dark flex flex-auto w-100 h2 pointer">
               ${renderSeeker({ force: true })}
             </div>
             <div class="flex w-100 flex-auto">
-              <div class="flex flex-auto w-100">
+              <div class="flex flex-auto w-100 pointer">
                 ${renderFullScreenButton()}
                 ${renderInfos(this.local.track)}
                 ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
@@ -501,9 +503,9 @@ class Player extends Nanocomponent {
           <div class="controls flex flex-auto w-100">
             ${renderFullScreenButton()}
             ${renderInfos(this.local.track)}
-            <div class="flex flex-auto-l w-auto w-100-l justify-end">
+            <div class="flex flex-auto-l w-auto w-100-l justify-end pointer">
               ${renderSeeker()}
-              <div class="flex items-center">
+              <div class="flex items-center pointer">
                 ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
                 ${renderVolumeControl({ force: true })}
                 ${playPauseButton}

--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -473,7 +473,7 @@ class Player extends Nanocomponent {
         return html`
           <div class="controls flex flex-column flex-auto flex-column h-100 bt bw b--mid-gray b--near-black--dark">
             <div class="flex flex-auto">
-              <div class="flex w-100 flex-auto ml2 pointer">
+              <div class="flex w-100 flex-auto ml2">
                 ${renderVolumeControl({ force: true })}
               </div>
               <div class="flex w-100 justify-center flex-auto">
@@ -485,7 +485,7 @@ class Player extends Nanocomponent {
                 ${!this.local.hideCount ? renderPlayCount() : ''}
               </div>
             </div>
-            <div class="bg-near-white bg-near-white--light bg-near-black--dark flex flex-auto w-100 h2 pointer">
+            <div class="bg-near-white bg-near-white--light bg-near-black--dark flex flex-auto w-100 h2">
               ${renderSeeker({ force: true })}
             </div>
             <div class="flex w-100 flex-auto">
@@ -503,9 +503,9 @@ class Player extends Nanocomponent {
           <div class="controls flex flex-auto w-100">
             ${renderFullScreenButton()}
             ${renderInfos(this.local.track)}
-            <div class="flex flex-auto-l w-auto w-100-l justify-end pointer">
+            <div class="flex flex-auto-l w-auto w-100-l justify-end">
               ${renderSeeker()}
-              <div class="flex items-center pointer">
+              <div class="flex items-center">
                 ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
                 ${renderVolumeControl({ force: true })}
                 ${playPauseButton}

--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -355,8 +355,11 @@ class Player extends Nanocomponent {
 
       return html`
         <div class="infos flex flex-auto w-auto w-33-l justify-center flex-column">
-          <div onclick=${() => { this.local.playback.emit(this.playing() ? 'pause' : 'play') }}>
-            <span class="track-title truncate f5 pointer no-underline underline-hover">
+          <div>
+            <span
+              class="track-title truncate f5 pointer no-underline underline-hover"
+              onclick=${() => { this.local.playback.emit(this.playing() ? 'pause' : 'play') }}
+              >
               ${title}
             </span>
           </div>

--- a/packages/seeker-component/index.js
+++ b/packages/seeker-component/index.js
@@ -59,7 +59,8 @@ class Seeker extends Nanocomponent {
         id: 'seeker',
         min: 0,
         max: 100,
-        value: 0
+        value: 0,
+        style: 'cursor: column-resize'
       }
       this._element = html`
         <div unresolved="unresolved" class="seeker h-100">

--- a/packages/tachyons/src/modules/_rangeSlider.css
+++ b/packages/tachyons/src/modules/_rangeSlider.css
@@ -10,12 +10,14 @@
 .rangeSlider__horizontal {
   height: 100%;
   width: 100%;
+  cursor: col-resize;
 }
 
 .rangeSlider__vertical {
   top: 1rem;
   height: calc(100% - 2rem);
   width: 100%;
+  cursor: row-resize;
 }
 
 .rangeSlider--disabled {

--- a/packages/tachyons/src/modules/_rangeSlider.css
+++ b/packages/tachyons/src/modules/_rangeSlider.css
@@ -53,7 +53,6 @@
 .rangeSlider__handle {
   opacity: 0;
   visibility: hidden;
-  cursor: pointer;
   display: none;
   width: 0;
   height: 0;
@@ -64,11 +63,13 @@
 .rangeSlider__handle__horizontal {
   top: 50%;
   left: -7px;
+  cursor: col-resize;
 }
 
 .rangeSlider__handle__vertical {
   left: calc(50% - 7px);
   bottom: 0;
+  cursor: row-resize;
 }
 
 .rangeSlider__handle__vertical:after {

--- a/packages/track-component/index.js
+++ b/packages/track-component/index.js
@@ -223,7 +223,7 @@ class Track extends Component {
 
     return html`
       <button ${attrs}>
-        <div class="play-button-inner flex items-center justify-center absolute w-100 h-100 top-0 pointer">
+        <div class="play-button-inner flex items-center justify-center absolute w-100 h-100 top-0">
           ${button}
         </div>
       </button>

--- a/packages/track-component/index.js
+++ b/packages/track-component/index.js
@@ -80,9 +80,7 @@ class Track extends Component {
         </div>
         <div class="flex flex-auto flex-shrink-0 justify-end items-center">
           ${showPlayCount ? renderPlayCount(this.local.count, this.local.track.id) : ''}
-          <div class="pointer">
-            ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
-          </div>
+          ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
           ${TimeElement(this.local.track.duration, { class: 'duration' })}
         </div>
       </li>

--- a/packages/track-component/index.js
+++ b/packages/track-component/index.js
@@ -23,7 +23,7 @@ class Track extends Component {
 
     this._handlePlayPause = this._handlePlayPause.bind(this)
     this._handleKeyPress = this._handleKeyPress.bind(this)
-    this._handleDoubleClick = this._handleDoubleClick.bind(this)
+    this._handleClick = this._handleClick.bind(this)
 
     this._isActive = this._isActive.bind(this)
     this._update = this._update.bind(this)
@@ -62,10 +62,12 @@ class Track extends Component {
       <li tabindex=0 class="track-component flex items-center w-100 mb2" onkeypress=${this._handleKeyPress}>
         <div class="flex items-center flex-auto">
           ${this.renderPlaybackButton()}
-          <div ondblclick=${this._handleDoubleClick} class="metas no-underline truncate flex flex-column pl2 pr2 items-start justify-center w-100">
-            <span class="pa0 track-title truncate f5 w-100">
-              ${this.local.track.title}
-            </span>
+          <div ondblclick=${this._handleClick} class="metas no-underline truncate flex flex-column pl2 pr2 items-start justify-center w-100">
+            <div onclick=${this._handleClick}>
+              <span class="pa0 track-title truncate f5 w-100">
+                ${this.local.track.title}
+              </span>
+            </div>
             ${showArtist ? renderArtist(this.local.track.artist) : ''}
           </div>
         </div>
@@ -267,7 +269,7 @@ class Track extends Component {
     this._update()
   }
 
-  _handleDoubleClick (e) {
+  _handleClick (e) {
     if (e.target.nodeName !== 'button') {
       return this._handlePlayPause(e)
     }

--- a/packages/track-component/index.js
+++ b/packages/track-component/index.js
@@ -57,23 +57,32 @@ class Track extends Component {
     const showArtist = props.showArtist
     const isAuthenticated = !!this.state.user.uid
     const showPlayCount = isAuthenticated && this.local.track.status !== 'free' && !this.local.hideCount
+    const goToArtistPage = () => {
+      if (this.local.track.creator_id) {
+        this.emit(this.state.events.PUSHSTATE, `/artist/${this.local.track.creator_id}`)
+      }
+    }
 
     return html`
       <li tabindex=0 class="track-component flex items-center w-100 mb2" onkeypress=${this._handleKeyPress}>
         <div class="flex items-center flex-auto">
           ${this.renderPlaybackButton()}
-          <div ondblclick=${this._handleClick} class="metas no-underline truncate flex flex-column pl2 pr2 items-start justify-center w-100">
-            <div onclick=${this._handleClick}>
-              <span class="pa0 track-title truncate f5 w-100">
+          <div class="metastruncate flex flex-column pl2 pr2 items-start justify-center w-100">
+            <div class="pointer" onclick=${this._handleClick} style="margin-left:-1em;">
+              <span class="pa0 track-title truncate f5 w-100 underline-hover" style="margin-left:1em;">
                 ${this.local.track.title}
               </span>
             </div>
-            ${showArtist ? renderArtist(this.local.track.artist) : ''}
+            <div class="pointer no-underline underline-hover" onclick=${goToArtistPage}>
+              ${showArtist ? renderArtist(this.local.track.artist) : ''}
+            </div>
           </div>
         </div>
         <div class="flex flex-auto flex-shrink-0 justify-end items-center">
           ${showPlayCount ? renderPlayCount(this.local.count, this.local.track.id) : ''}
-          ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
+          <div class="pointer">
+            ${!this.local.hideMenu ? this.renderMenuButtonOptions() : ''}
+          </div>
           ${TimeElement(this.local.track.duration, { class: 'duration' })}
         </div>
       </li>
@@ -185,7 +194,7 @@ class Track extends Component {
       const imageUrl = this.local.track.cover ? this.local.track.cover.replace('600x600', '120x120').replace('-x600', '-x120') : imagePlaceholder(120, 120)
 
       return html`
-        <span class="db w-100 aspect-ratio aspect-ratio--1x1 bg-near-black">
+        <span class="db w-100 aspect-ratio aspect-ratio--1x1 bg-near-black pointer ">
           <img src=${imageUrl} decoding="auto" class="z-1 aspect-ratio--object">
           ${this._isActive() || this.machine.state.hover === 'on'
             ? html`
@@ -216,7 +225,7 @@ class Track extends Component {
 
     return html`
       <button ${attrs}>
-        <div class="play-button-inner flex items-center justify-center absolute w-100 h-100 top-0">
+        <div class="play-button-inner flex items-center justify-center absolute w-100 h-100 top-0 pointer">
           ${button}
         </div>
       </button>

--- a/packages/volume-control-component/index.js
+++ b/packages/volume-control-component/index.js
@@ -113,7 +113,7 @@ class VolumeControl extends Component {
 
     return html`
       <div class="flex w-100">
-        <div class="relative pointer" onmouseenter=${this._handleMouseEnter} onmouseleave=${this._handleMouseLeave}>
+        <div class="relative" onmouseenter=${this._handleMouseEnter} onmouseleave=${this._handleMouseLeave}>
           ${button({
             iconName: 'volume',
             onClick: this._handleClick,

--- a/packages/volume-control-component/index.js
+++ b/packages/volume-control-component/index.js
@@ -113,7 +113,7 @@ class VolumeControl extends Component {
 
     return html`
       <div class="flex w-100">
-        <div class="relative" onmouseenter=${this._handleMouseEnter} onmouseleave=${this._handleMouseLeave}>
+        <div class="relative pointer" onmouseenter=${this._handleMouseEnter} onmouseleave=${this._handleMouseLeave}>
           ${button({
             iconName: 'volume',
             onClick: this._handleClick,


### PR DESCRIPTION
Recreating: https://github.com/resonatecoop/stream/pull/212

These changes allow for a user to click anywhere on a track's title to play or pause the song for any trackgroup (such as [this](https://stream.resonate.coop/artist/13946/release/shut-the-fuck-up-talking-to-me)).

On mobile, it was unclear for users how to play songs, as the play buttons would be numbers. On desktop, when you mouse over the number it becomes a play button, but mobile users do not have `hover` so it's unclear. These changes make it so pressing on a track's title plays the track, and pressing on a different track's title plays that track instead, just the same as clicking the play button on the left for that track. This makes it way easier to change tracks, since the play/pause button is small, this gives users a bigger area where they can click/press.